### PR TITLE
More flexible layers

### DIFF
--- a/vacs-map-app/src/App.vue
+++ b/vacs-map-app/src/App.vue
@@ -15,6 +15,7 @@ import { computed, ref } from 'vue';
 import MapContainerColor from '@/components/MapContainerColor.vue';
 import MapContainerColorRadius from '@/components/MapContainerColorRadius.vue';
 import MapContainerNotFilled from '@/components/MapContainerNotFilled.vue';
+import MapContainerNotFilledTwoLayers from '@/components/MapContainerNotFilledTwoLayers.vue';
 import Filters from '@/components/Filters.vue';
 
 const availableMaps = [
@@ -32,6 +33,11 @@ const availableMaps = [
     id: 'not-filled',
     name: 'circles not filled',
     component: MapContainerNotFilled,
+  },
+  {
+    id: 'not-filled-2',
+    name: 'circles not filled, two layers',
+    component: MapContainerNotFilledTwoLayers,
   },
 ];
 const selectedMap = ref(availableMaps[0].id);

--- a/vacs-map-app/src/App.vue
+++ b/vacs-map-app/src/App.vue
@@ -14,6 +14,7 @@
 import { computed, ref } from 'vue';
 import MapContainerColor from '@/components/MapContainerColor.vue';
 import MapContainerColorRadius from '@/components/MapContainerColorRadius.vue';
+import MapContainerNotFilled from '@/components/MapContainerNotFilled.vue';
 import Filters from '@/components/Filters.vue';
 
 const availableMaps = [
@@ -26,6 +27,11 @@ const availableMaps = [
     id: 'color-and-radius-1',
     name: 'dynamic color and radius (cropyield)',
     component: MapContainerColorRadius,
+  },
+  {
+    id: 'not-filled',
+    name: 'circles not filled',
+    component: MapContainerNotFilled,
   },
 ];
 const selectedMap = ref(availableMaps[0].id);

--- a/vacs-map-app/src/App.vue
+++ b/vacs-map-app/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <main>
-    <BaseMap />
+    <MapContainer />
     <div class="overlay">
       <Filters />
     </div>
@@ -8,7 +8,7 @@
 </template>
 
 <script setup>
-import BaseMap from '@/components/BaseMap.vue';
+import MapContainer from '@/components/MapContainer.vue';
 import Filters from '@/components/Filters.vue';
 </script>
 

--- a/vacs-map-app/src/App.vue
+++ b/vacs-map-app/src/App.vue
@@ -1,21 +1,59 @@
 <template>
   <main>
-    <MapContainer />
-    <div class="overlay">
+    <div class="top-bar">
+      <select v-model="selectedMap">
+        <option v-for="map in availableMaps" :value="map.id">{{ map.name }}</option>
+      </select>
       <Filters />
     </div>
+    <component :is="selectedMapComponent" />
   </main>
 </template>
 
 <script setup>
-import MapContainer from '@/components/MapContainer.vue';
+import { computed, ref } from 'vue';
+import MapContainerColor from '@/components/MapContainerColor.vue';
+import MapContainerColorRadius from '@/components/MapContainerColorRadius.vue';
 import Filters from '@/components/Filters.vue';
+
+const availableMaps = [
+  {
+    id: 'just-color',
+    name: 'dynamic color',
+    component: MapContainerColor,
+  },
+  {
+    id: 'color-and-radius-1',
+    name: 'dynamic color and radius (cropyield)',
+    component: MapContainerColorRadius,
+  },
+];
+const selectedMap = ref(availableMaps[0].id);
+const selectedMapComponent = computed(() => {
+  return availableMaps.find(({ id }) => id === selectedMap.value).component;
+});
 </script>
 
 <style scoped>
+main {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+.top-bar {
+  padding: 0.5rem 2rem;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  align-items: center;
+}
+
 .overlay {
   position: absolute;
   left: 1rem;
-  top: 1rem;
+  top: 3rem;
 }
 </style>

--- a/vacs-map-app/src/components/BaseMap.vue
+++ b/vacs-map-app/src/components/BaseMap.vue
@@ -1,12 +1,23 @@
 <template>
   <div class="base-map-wrapper">
     <div id="baseMapContainer" class="base-map"></div>
-    <GridOverlay :map="map" :mapReady="mapReady" />
+    <GridSource :id="sourceId" :map="map" :mapReady="mapReady" />
+    <GridOverlay
+      id="grid-layer-1"
+      :color-column="selectedColumn"
+      :color-column-extent="selectedColumnExtent"
+      :color-column-quintiles="selectedColumnQuintiles"
+      :color-diverging="false"
+      :sourceId="sourceId"
+      :map="map"
+      :mapReady="mapReady"
+      />
   </div>
 </template>
 
 <script setup>
-import { onMounted, ref, shallowRef } from 'vue';
+import { computed, onMounted, ref, shallowRef } from 'vue';
+import { storeToRefs } from 'pinia';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import {
@@ -14,10 +25,45 @@ import {
   MAPBOX_GL_ACCESS_TOKEN,
   MAPBOX_STYLE,
 } from '@/constants';
+import { useFiltersStore } from '@/stores/filters';
+import { useCropYieldsStore } from '@/stores/cropYields';
+import GridSource from './GridSource.vue';
 import GridOverlay from './GridOverlay.vue';
 
 const map = shallowRef(null);
 const mapReady = ref(false);
+const sourceId = 'cropGrid';
+
+const cropYieldsStore = useCropYieldsStore();
+const filtersStore = useFiltersStore();
+
+const {
+  selectedCrop,
+  selectedMetric,
+  selectedModel
+} = storeToRefs(filtersStore);
+
+const selectedColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  return [
+    selectedMetric.value,
+    selectedCrop.value,
+    selectedModel.value,
+  ].join('_');
+});
+
+const selectedColumnExtent = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getExtent(selectedColumn.value);
+});
+
+const selectedColumnQuintiles = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getQuintiles(selectedColumn.value);
+});
 
 const initializeMap = () => {
   mapboxgl.accessToken = MAPBOX_GL_ACCESS_TOKEN;

--- a/vacs-map-app/src/components/BaseMap.vue
+++ b/vacs-map-app/src/components/BaseMap.vue
@@ -8,6 +8,8 @@
       :color-column-extent="selectedColumnExtent"
       :color-column-quintiles="selectedColumnQuintiles"
       :color-diverging="false"
+      :radius-column="radiusColumn"
+      :radius-column-extent="radiusColumnExtent"
       :sourceId="sourceId"
       :map="map"
       :mapReady="mapReady"
@@ -63,6 +65,25 @@ const selectedColumnExtent = computed(() => {
 const selectedColumnQuintiles = computed(() => {
   if (!selectedColumn.value) return null;
   return cropYieldsStore.getQuintiles(selectedColumn.value);
+});
+
+const radiusColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  // As an  example, adding a radius column that is always the yield ratio for
+  // the selected crop + model
+  return [
+    'yieldratio',
+    selectedCrop.value,
+    selectedModel.value,
+  ].join('_');
+});
+
+const radiusColumnExtent = computed(() => {
+  if (!radiusColumn.value) return null;
+  return cropYieldsStore.getExtent(radiusColumn.value);
 });
 
 const initializeMap = () => {

--- a/vacs-map-app/src/components/BaseMap.vue
+++ b/vacs-map-app/src/components/BaseMap.vue
@@ -44,8 +44,11 @@ onMounted(() => {
 </script>
 
 <style scoped>
+.base-map-wrapper {
+  flex-grow: 1;
+}
+
 .base-map {
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
 }
 </style>

--- a/vacs-map-app/src/components/BaseMap.vue
+++ b/vacs-map-app/src/components/BaseMap.vue
@@ -1,25 +1,12 @@
 <template>
   <div class="base-map-wrapper">
     <div id="baseMapContainer" class="base-map"></div>
-    <GridSource :id="sourceId" :map="map" :mapReady="mapReady" />
-    <GridOverlay
-      id="grid-layer-1"
-      :color-column="selectedColumn"
-      :color-column-extent="selectedColumnExtent"
-      :color-column-quintiles="selectedColumnQuintiles"
-      :color-diverging="false"
-      :radius-column="radiusColumn"
-      :radius-column-extent="radiusColumnExtent"
-      :sourceId="sourceId"
-      :map="map"
-      :mapReady="mapReady"
-      />
+    <slot :map="map" :map-ready="mapReady"></slot>
   </div>
 </template>
 
 <script setup>
-import { computed, onMounted, ref, shallowRef } from 'vue';
-import { storeToRefs } from 'pinia';
+import { onMounted, ref, shallowRef } from 'vue';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import {
@@ -27,64 +14,9 @@ import {
   MAPBOX_GL_ACCESS_TOKEN,
   MAPBOX_STYLE,
 } from '@/constants';
-import { useFiltersStore } from '@/stores/filters';
-import { useCropYieldsStore } from '@/stores/cropYields';
-import GridSource from './GridSource.vue';
-import GridOverlay from './GridOverlay.vue';
 
 const map = shallowRef(null);
 const mapReady = ref(false);
-const sourceId = 'cropGrid';
-
-const cropYieldsStore = useCropYieldsStore();
-const filtersStore = useFiltersStore();
-
-const {
-  selectedCrop,
-  selectedMetric,
-  selectedModel
-} = storeToRefs(filtersStore);
-
-const selectedColumn = computed(() => {
-  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
-    return null;
-  }
-
-  return [
-    selectedMetric.value,
-    selectedCrop.value,
-    selectedModel.value,
-  ].join('_');
-});
-
-const selectedColumnExtent = computed(() => {
-  if (!selectedColumn.value) return null;
-  return cropYieldsStore.getExtent(selectedColumn.value);
-});
-
-const selectedColumnQuintiles = computed(() => {
-  if (!selectedColumn.value) return null;
-  return cropYieldsStore.getQuintiles(selectedColumn.value);
-});
-
-const radiusColumn = computed(() => {
-  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
-    return null;
-  }
-
-  // As an  example, adding a radius column that is always the yield ratio for
-  // the selected crop + model
-  return [
-    'yieldratio',
-    selectedCrop.value,
-    selectedModel.value,
-  ].join('_');
-});
-
-const radiusColumnExtent = computed(() => {
-  if (!radiusColumn.value) return null;
-  return cropYieldsStore.getExtent(radiusColumn.value);
-});
 
 const initializeMap = () => {
   mapboxgl.accessToken = MAPBOX_GL_ACCESS_TOKEN;

--- a/vacs-map-app/src/components/Filters.vue
+++ b/vacs-map-app/src/components/Filters.vue
@@ -57,10 +57,8 @@ const {
 
 <style scoped>
 .filters {
-  background: white;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: 0.5rem;
-  padding: 1rem;
 }
 </style>

--- a/vacs-map-app/src/components/GridOverlay.vue
+++ b/vacs-map-app/src/components/GridOverlay.vue
@@ -2,21 +2,34 @@
 
 <script setup>
 import * as d3 from 'd3';
-import { computed, onMounted, toRefs, watch } from 'vue';
-import { storeToRefs } from 'pinia';
-import { point, featureCollection } from '@turf/helpers';
-import { useFiltersStore } from '@/stores/filters';
-import { useCropYieldsStore } from '@/stores/cropYields';
-import { useGridStore } from '@/stores/grid';
-
-const LAYER_ID = 'grid-overlay';
-const SOURCE_ID = 'grid-overlay';
-
-const cropYieldsStore = useCropYieldsStore();
-const filtersStore = useFiltersStore();
-const gridStore = useGridStore();
+import { computed, toRefs, watch } from 'vue';
 
 const props = defineProps({
+  id: {
+    type: String,
+    default: '',
+  },
+
+  colorColumn: {
+    type: String,
+    default: '',
+  },
+
+  colorColumnExtent: {
+    type: Array,
+    default: () => [],
+  },
+
+  colorColumnQuintiles: {
+    type: Array,
+    default: () => [],
+  },
+
+  colorDiverging: {
+    type: Boolean,
+    default: false,
+  },
+
   map: {
     type: Object,
     default: null,
@@ -26,79 +39,29 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-});
 
-const { map, mapReady } = toRefs(props);
+  sourceId: {
+    type: String,
+    default: '',
+  },
+});
 
 const {
-  selectedCrop,
-  selectedMetric,
-  selectedModel
-} = storeToRefs(filtersStore);
-const { data: cropYieldsData } = storeToRefs(cropYieldsStore);
-const { data: gridData } = storeToRefs(gridStore);
-
-const selectedColumn = computed(() => {
-  return [
-    selectedMetric.value,
-    selectedCrop.value,
-    selectedModel.value,
-  ].join('_');
-});
-
-const selectedColumnExtent = computed(() => {
-  return cropYieldsStore.getExtent(selectedColumn.value);
-});
-
-const selectedColumnQuintiles = computed(() => {
-  return cropYieldsStore.getQuintiles(selectedColumn.value);
-});
-
-onMounted(() => {
-  gridStore.load();
-  cropYieldsStore.load();
-});
-
-// TODO do this stuff in another store?
-const joinData = (grid, yields) => {
-  const joined = Object.fromEntries(grid.map(row => ([row.id, row])));
-  yields
-    .forEach(row => {
-      if (joined[row.id]) {
-        joined[row.id] = { ...joined[row.id], ...row};
-      }
-    })
-  return Object.values(joined);
-};
-
-const joinedData = computed(() => {
-  if (!gridData.value) return [];
-  if (cropYieldsData.value) {
-    return joinData(gridData.value, cropYieldsData.value);
-  }
-  return gridData.value;
-});
-
-const joinedGeoJson = computed(() => {
-  return featureCollection(
-    joinedData.value.map(row => point([row.X, row.Y], row, { id: row.id }))
-  );
-});
-
-const addSource = (geoJson) => {
-  if (!map.value || !mapReady.value || map.value.getSource(SOURCE_ID)) return;
-
-  map.value.addSource(SOURCE_ID, {
-    type: 'geojson',
-    data: geoJson,
-  });
-};
+  id,
+  colorColumn,
+  colorColumnExtent,
+  colorColumnQuintiles,
+  colorDiverging,
+  map,
+  mapReady,
+  sourceId
+} = toRefs(props);
 
 const addLayer = () => {
-  if (!map.value || !mapReady.value || map.value.getLayer(LAYER_ID)) return;
+  if (!map.value || !mapReady.value || map.value.getLayer(id.value)) return;
   map.value.addLayer({
-    id: LAYER_ID,
-    source: SOURCE_ID,
+    id: id.value,
+    source: sourceId.value,
     type: 'circle',
     paint: {
       'circle-radius': [
@@ -118,11 +81,6 @@ const addLayer = () => {
   }, 'country-label-filter');
 
   updateLayer();
-};
-
-const addLayerToMap = (geoJson) => {
-  addSource(geoJson);
-  addLayer();
 };
 
 const getCircleColorQuintiles = (quintiles) => {
@@ -146,11 +104,11 @@ const getCircleColorQuintiles = (quintiles) => {
   // to strict buckets if we prefer.
   return [
     'case',
-    ['!=', ['get', selectedColumn.value], null],
+    ['!=', ['get', colorColumn.value], null],
     [
       'interpolate',
       ['linear'],
-      ['get', selectedColumn.value],
+      ['get', colorColumn.value],
       ...quintiles.map(({ value, quantile }) => ([value, getColor(quantile)])).flat()
     ],
     'transparent',
@@ -194,11 +152,11 @@ const getCircleColorExtent = (extent) => {
 
   return [
     'case',
-    ['!=', ['get', selectedColumn.value], null],
+    ['!=', ['get', colorColumn.value], null],
     [
       'interpolate',
       ['linear'],
-      ['get', selectedColumn.value],
+      ['get', colorColumn.value],
       min, 'red',
       middle, 'yellow',
       max, 'green',
@@ -224,11 +182,11 @@ const getCircleColorDiverging = (extent, center) => {
 
   return [
     'case',
-    ['!=', ['get', selectedColumn.value], null],
+    ['!=', ['get', colorColumn.value], null],
     [
       'interpolate',
       ['linear'],
-      ['get', selectedColumn.value],
+      ['get', colorColumn.value],
       min, getColor(0),
       center, getColor(0.5),
       max, getColor(1),
@@ -238,44 +196,30 @@ const getCircleColorDiverging = (extent, center) => {
 }
 
 const getCircleColor = () => {
-  if (selectedMetric.value === 'yieldratio') {
+  if (colorDiverging.value) {
     // < 1, decrease
     // 1 = no change
     // > 1, increase
-    return getCircleColorDiverging(selectedColumnExtent.value, 1);
+    return getCircleColorDiverging(colorColumnExtent.value, 1);
   }
 
-  return getCircleColorQuintiles(selectedColumnQuintiles.value);
+  return getCircleColorQuintiles(colorColumnQuintiles.value);
 
   // Defaulting to using quintiles but here's how to invoke another method:
-  // return getCircleColorExtent(selectedColumnExtent.value);
+  // return getCircleColorExtent(colorColumnExtent.value);
 };
 
 const updateLayer = () => {
-  if (!map.value.getLayer(LAYER_ID)) return;
-  map.value.setPaintProperty(LAYER_ID, 'circle-color', getCircleColor());
-  // map.value.setPaintProperty(LAYER_ID, 'circle-radius', getCircleRadius());
+  if (!map.value.getLayer(id.value)) return;
+  map.value.setPaintProperty(id.value, 'circle-color', getCircleColor());
+  // map.value.setPaintProperty(id.value, 'circle-radius', getCircleRadius());
 };
 
 watch(mapReady, () => {
-  if (!joinedGeoJson.value) return;
-  addLayerToMap(joinedGeoJson.value);
+  addLayer();
 });
 
-watch(joinedGeoJson, () => {
-  if (!joinedGeoJson.value) return;
-  addLayerToMap(joinedGeoJson.value);
-});
-
-watch(selectedMetric, () => {
-  updateLayer();
-});
-
-watch(selectedModel, () => {
-  updateLayer();
-});
-
-watch(selectedCrop, () => {
+watch(colorColumn, () => {
   updateLayer();
 });
 </script>

--- a/vacs-map-app/src/components/GridOverlay.vue
+++ b/vacs-map-app/src/components/GridOverlay.vue
@@ -40,6 +40,16 @@ const props = defineProps({
     default: () => [],
   },
 
+  fill: {
+    type: Boolean,
+    default: true,
+  },
+
+  stroke: {
+    type: Boolean,
+    default: false,
+  },
+
   map: {
     type: Object,
     default: null,
@@ -62,11 +72,13 @@ const {
   colorColumnExtent,
   colorColumnQuintiles,
   colorDiverging,
+  fill,
   radiusColumn,
   radiusColumnExtent,
   map,
   mapReady,
-  sourceId
+  sourceId,
+  stroke,
 } = toRefs(props);
 
 const addLayer = () => {
@@ -77,11 +89,11 @@ const addLayer = () => {
     type: 'circle',
     paint: {
       'circle-radius': getCircleRadius(),
-      'circle-stroke-width': 0.2,
-      'circle-stroke-color': 'gray',
-      'circle-stroke-opacity': 0,
+      'circle-stroke-width': fill.value ? 0.2 : 1.5,
+      'circle-stroke-color': getCircleStrokeColor(),
+      'circle-stroke-opacity': fill.value ? 0 : 0.8,
       'circle-opacity': 1,
-      'circle-color': getCircleColor(),
+      'circle-color': getCircleFillColor(),
     }
   }, 'country-label-filter');
 
@@ -218,6 +230,16 @@ const getCircleColorDiverging = (extent, center) => {
   ];
 }
 
+const getCircleFillColor = () => {
+  if (!fill.value) return 'transparent';
+  return getCircleColor();
+};
+
+const getCircleStrokeColor = () => {
+  if (!stroke.value) return 'transparent';
+  return getCircleColor();
+};
+
 const getCircleColor = () => {
   if (colorDiverging.value) {
     // < 1, decrease
@@ -234,7 +256,8 @@ const getCircleColor = () => {
 
 const updateLayer = () => {
   if (!map.value.getLayer(id.value)) return;
-  map.value.setPaintProperty(id.value, 'circle-color', getCircleColor());
+  map.value.setPaintProperty(id.value, 'circle-color', getCircleFillColor());
+  map.value.setPaintProperty(id.value, 'circle-stroke-color', getCircleStrokeColor());
   map.value.setPaintProperty(id.value, 'circle-radius', getCircleRadius());
 };
 

--- a/vacs-map-app/src/components/GridSource.vue
+++ b/vacs-map-app/src/components/GridSource.vue
@@ -1,0 +1,86 @@
+<template></template>
+
+<script setup>
+import { computed, onMounted, toRefs, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+import { point, featureCollection } from '@turf/helpers';
+import { useCropYieldsStore } from '@/stores/cropYields';
+import { useGridStore } from '@/stores/grid';
+
+const props = defineProps({
+  id: {
+    type: String,
+    default: '',
+  },
+
+  map: {
+    type: Object,
+    default: null,
+  },
+
+  mapReady: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const { id, map, mapReady } = toRefs(props);
+
+const cropYieldsStore = useCropYieldsStore();
+const gridStore = useGridStore();
+
+const { data: cropYieldsData } = storeToRefs(cropYieldsStore);
+const { data: gridData } = storeToRefs(gridStore);
+
+onMounted(() => {
+  gridStore.load();
+  cropYieldsStore.load();
+});
+
+// TODO do this stuff in another store?
+const joinData = (grid, yields) => {
+  const joined = Object.fromEntries(grid.map(row => ([row.id, row])));
+  yields
+    .forEach(row => {
+      if (joined[row.id]) {
+        joined[row.id] = { ...joined[row.id], ...row};
+      }
+    })
+  return Object.values(joined);
+};
+
+const joinedData = computed(() => {
+  if (!gridData.value) return [];
+  if (cropYieldsData.value) {
+    return joinData(gridData.value, cropYieldsData.value);
+  }
+  return gridData.value;
+});
+
+const joinedGeoJson = computed(() => {
+  return featureCollection(
+    joinedData.value.map(row => point([row.X, row.Y], row, { id: row.id }))
+  );
+});
+
+const addSource = (geoJson) => {
+  if (!map.value || !mapReady.value || map.value.getSource(id)) return;
+
+  map.value.addSource(id.value, {
+    type: 'geojson',
+    data: geoJson,
+  });
+};
+
+watch(mapReady, () => {
+  if (!joinedGeoJson.value) return;
+  addSource(joinedGeoJson.value);
+});
+
+watch(joinedGeoJson, () => {
+  if (!joinedGeoJson.value) return;
+  addSource(joinedGeoJson.value);
+});
+</script>
+
+<style></style>

--- a/vacs-map-app/src/components/MapContainer.vue
+++ b/vacs-map-app/src/components/MapContainer.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="map-container">
+    <BaseMap>
+      <template v-slot="{ map, mapReady }">
+        <GridSource :id="sourceId" :map="map" :mapReady="mapReady" />
+        <GridOverlay
+          id="grid-layer-1"
+          :color-column="selectedColumn"
+          :color-column-extent="selectedColumnExtent"
+          :color-column-quintiles="selectedColumnQuintiles"
+          :color-diverging="false"
+          :radius-column="radiusColumn"
+          :radius-column-extent="radiusColumnExtent"
+          :sourceId="sourceId"
+          :map="map"
+          :mapReady="mapReady"
+        />
+      </template>
+    </BaseMap>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import BaseMap from '@/components/BaseMap.vue';
+import { useFiltersStore } from '@/stores/filters';
+import { useCropYieldsStore } from '@/stores/cropYields';
+import GridSource from './GridSource.vue';
+import GridOverlay from './GridOverlay.vue';
+
+const sourceId = 'cropGrid';
+const cropYieldsStore = useCropYieldsStore();
+const filtersStore = useFiltersStore();
+
+const {
+  selectedCrop,
+  selectedMetric,
+  selectedModel
+} = storeToRefs(filtersStore);
+
+const selectedColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  return [
+    selectedMetric.value,
+    selectedCrop.value,
+    selectedModel.value,
+  ].join('_');
+});
+
+const selectedColumnExtent = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getExtent(selectedColumn.value);
+});
+
+const selectedColumnQuintiles = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getQuintiles(selectedColumn.value);
+});
+
+const radiusColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  // As an  example, adding a radius column that is always the yield ratio for
+  // the selected crop + model
+  return [
+    'yieldratio',
+    selectedCrop.value,
+    selectedModel.value,
+  ].join('_');
+});
+
+const radiusColumnExtent = computed(() => {
+  if (!radiusColumn.value) return null;
+  return cropYieldsStore.getExtent(radiusColumn.value);
+});
+</script>
+
+<style scoped></style>

--- a/vacs-map-app/src/components/MapContainerColor.vue
+++ b/vacs-map-app/src/components/MapContainerColor.vue
@@ -1,23 +1,19 @@
 <template>
-  <div class="map-container">
-    <BaseMap>
-      <template v-slot="{ map, mapReady }">
-        <GridSource :id="sourceId" :map="map" :mapReady="mapReady" />
-        <GridOverlay
-          id="grid-layer-1"
-          :color-column="selectedColumn"
-          :color-column-extent="selectedColumnExtent"
-          :color-column-quintiles="selectedColumnQuintiles"
-          :color-diverging="false"
-          :radius-column="radiusColumn"
-          :radius-column-extent="radiusColumnExtent"
-          :sourceId="sourceId"
-          :map="map"
-          :mapReady="mapReady"
-        />
-      </template>
-    </BaseMap>
-  </div>
+  <BaseMap>
+    <template v-slot="{ map, mapReady }">
+      <GridSource :id="sourceId" :map="map" :mapReady="mapReady" />
+      <GridOverlay
+        id="grid-layer-1"
+        :color-column="selectedColumn"
+        :color-column-extent="selectedColumnExtent"
+        :color-column-quintiles="selectedColumnQuintiles"
+        :color-diverging="false"
+        :sourceId="sourceId"
+        :map="map"
+        :mapReady="mapReady"
+      />
+    </template>
+  </BaseMap>
 </template>
 
 <script setup>
@@ -59,25 +55,6 @@ const selectedColumnExtent = computed(() => {
 const selectedColumnQuintiles = computed(() => {
   if (!selectedColumn.value) return null;
   return cropYieldsStore.getQuintiles(selectedColumn.value);
-});
-
-const radiusColumn = computed(() => {
-  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
-    return null;
-  }
-
-  // As an  example, adding a radius column that is always the yield ratio for
-  // the selected crop + model
-  return [
-    'yieldratio',
-    selectedCrop.value,
-    selectedModel.value,
-  ].join('_');
-});
-
-const radiusColumnExtent = computed(() => {
-  if (!radiusColumn.value) return null;
-  return cropYieldsStore.getExtent(radiusColumn.value);
 });
 </script>
 

--- a/vacs-map-app/src/components/MapContainerColorRadius.vue
+++ b/vacs-map-app/src/components/MapContainerColorRadius.vue
@@ -1,0 +1,82 @@
+<template>
+  <BaseMap>
+    <template v-slot="{ map, mapReady }">
+      <GridSource :id="sourceId" :map="map" :mapReady="mapReady" />
+      <GridOverlay
+        id="grid-layer-1"
+        :color-column="selectedColumn"
+        :color-column-extent="selectedColumnExtent"
+        :color-column-quintiles="selectedColumnQuintiles"
+        :color-diverging="false"
+        :radius-column="radiusColumn"
+        :radius-column-extent="radiusColumnExtent"
+        :sourceId="sourceId"
+        :map="map"
+        :mapReady="mapReady"
+      />
+    </template>
+  </BaseMap>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import BaseMap from '@/components/BaseMap.vue';
+import { useFiltersStore } from '@/stores/filters';
+import { useCropYieldsStore } from '@/stores/cropYields';
+import GridSource from './GridSource.vue';
+import GridOverlay from './GridOverlay.vue';
+
+const sourceId = 'cropGrid';
+const cropYieldsStore = useCropYieldsStore();
+const filtersStore = useFiltersStore();
+
+const {
+  selectedCrop,
+  selectedMetric,
+  selectedModel
+} = storeToRefs(filtersStore);
+
+const selectedColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  return [
+    selectedMetric.value,
+    selectedCrop.value,
+    selectedModel.value,
+  ].join('_');
+});
+
+const selectedColumnExtent = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getExtent(selectedColumn.value);
+});
+
+const selectedColumnQuintiles = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getQuintiles(selectedColumn.value);
+});
+
+const radiusColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  // As an  example, adding a radius column that is always the yield ratio for
+  // the selected crop + model
+  return [
+    'yieldratio',
+    selectedCrop.value,
+    selectedModel.value,
+  ].join('_');
+});
+
+const radiusColumnExtent = computed(() => {
+  if (!radiusColumn.value) return null;
+  return cropYieldsStore.getExtent(radiusColumn.value);
+});
+</script>
+
+<style scoped></style>

--- a/vacs-map-app/src/components/MapContainerNotFilled.vue
+++ b/vacs-map-app/src/components/MapContainerNotFilled.vue
@@ -1,0 +1,63 @@
+<template>
+  <BaseMap>
+    <template v-slot="{ map, mapReady }">
+      <GridSource :id="sourceId" :map="map" :mapReady="mapReady" />
+      <GridOverlay
+        id="grid-layer-1"
+        :color-column="selectedColumn"
+        :color-column-extent="selectedColumnExtent"
+        :color-column-quintiles="selectedColumnQuintiles"
+        :color-diverging="false"
+        :fill="false"
+        :stroke="true"
+        :sourceId="sourceId"
+        :map="map"
+        :mapReady="mapReady"
+      />
+    </template>
+  </BaseMap>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import BaseMap from '@/components/BaseMap.vue';
+import { useFiltersStore } from '@/stores/filters';
+import { useCropYieldsStore } from '@/stores/cropYields';
+import GridSource from './GridSource.vue';
+import GridOverlay from './GridOverlay.vue';
+
+const sourceId = 'cropGrid';
+const cropYieldsStore = useCropYieldsStore();
+const filtersStore = useFiltersStore();
+
+const {
+  selectedCrop,
+  selectedMetric,
+  selectedModel
+} = storeToRefs(filtersStore);
+
+const selectedColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  return [
+    selectedMetric.value,
+    selectedCrop.value,
+    selectedModel.value,
+  ].join('_');
+});
+
+const selectedColumnExtent = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getExtent(selectedColumn.value);
+});
+
+const selectedColumnQuintiles = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getQuintiles(selectedColumn.value);
+});
+</script>
+
+<style scoped></style>

--- a/vacs-map-app/src/components/MapContainerNotFilledTwoLayers.vue
+++ b/vacs-map-app/src/components/MapContainerNotFilledTwoLayers.vue
@@ -1,0 +1,102 @@
+<template>
+  <BaseMap>
+    <template v-slot="{ map, mapReady }">
+      <GridSource :id="sourceId" :map="map" :mapReady="mapReady" />
+      <GridOverlay
+        id="grid-layer-1"
+        :color-column="selectedColumn"
+        :color-column-extent="selectedColumnExtent"
+        :color-column-quintiles="selectedColumnQuintiles"
+        :color-diverging="false"
+        :radius-column="selectedColumn"
+        :radius-column-extent="selectedColumnExtent"
+        :fill="false"
+        :stroke="true"
+        :sourceId="sourceId"
+        :map="map"
+        :mapReady="mapReady"
+      />
+      <GridOverlay
+        id="grid-layer-2"
+        :color-column="comparisonColumn"
+        :color-column-extent="comparisonColumnExtent"
+        :color-column-quintiles="comparisonColumnQuintiles"
+        :color-diverging="false"
+        :radius-column="comparisonColumn"
+        :radius-column-extent="comparisonColumnExtent"
+        :fill="false"
+        :stroke="true"
+        :sourceId="sourceId"
+        :map="map"
+        :mapReady="mapReady"
+      />
+    </template>
+  </BaseMap>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import BaseMap from '@/components/BaseMap.vue';
+import { useFiltersStore } from '@/stores/filters';
+import { useCropYieldsStore } from '@/stores/cropYields';
+import GridSource from './GridSource.vue';
+import GridOverlay from './GridOverlay.vue';
+
+const sourceId = 'cropGrid';
+const cropYieldsStore = useCropYieldsStore();
+const filtersStore = useFiltersStore();
+
+const {
+  selectedCrop,
+  selectedMetric,
+  selectedModel
+} = storeToRefs(filtersStore);
+
+const selectedColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  return [
+    selectedMetric.value,
+    selectedCrop.value,
+    selectedModel.value,
+  ].join('_');
+});
+
+const selectedColumnExtent = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getExtent(selectedColumn.value);
+});
+
+const selectedColumnQuintiles = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getQuintiles(selectedColumn.value);
+});
+
+// Comparison column just always shows maize
+const comparisonColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  return [
+    selectedMetric.value,
+    'maize',
+    selectedModel.value,
+  ].join('_');
+});
+
+const comparisonColumnExtent = computed(() => {
+  if (!comparisonColumn.value) return null;
+  return cropYieldsStore.getExtent(comparisonColumn.value);
+});
+
+const comparisonColumnQuintiles = computed(() => {
+  if (!comparisonColumn.value) return null;
+  return cropYieldsStore.getQuintiles(comparisonColumn.value);
+});
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
Closes #2 
Closes #3 

This PR refactors the code base a bit. I'm trying to navigate between making it easier to experiment and add new map instances and also account for the likelihood that the final app will have a number of distinct map instances. So some styling change may require code changes but I think things are a lot more flexible now and will be able to accommodate most needs.

Here's the new map selector:

![image](https://github.com/earthrise-media/vacs-map/assets/375002/d5cdec7e-8e3e-43e5-a6e2-fdfabcb50e0f)

basically I'm thinking while we work through map variants we'll keep a bunch of them around and this dropdown will allow use to pick one. These maps also demonstrate various styles implemented currently.

Through the map selector you can see that we now support multiple grid layers, stroke-only grid layers, and dynamic radii.