### PR TITLE
Add d3 map to homepage

### DIFF
--- a/vacs-map-app/package-lock.json
+++ b/vacs-map-app/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@turf/bbox": "^6.5.0",
         "@turf/helpers": "^6.5.0",
+        "@vueuse/core": "^10.6.1",
         "autoprefixer": "^10.4.16",
         "d3": "^7.8.5",
+        "d3-geo-projection": "^4.0.0",
         "mapbox-gl": "^3.0.0-rc.2",
         "pinia": "^2.1.7",
         "qs": "^6.11.2",
@@ -307,6 +309,11 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
@@ -446,6 +453,89 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.7.tgz",
       "integrity": "sha512-N/tbkINRUDExgcPTBvxNkvHGu504k8lzlNQRITVnm6YjOjwa4r0nnbd4Jb01sNpur5hAllyRJzSK5PvB9PPwRg=="
+    },
+    "node_modules/@vueuse/core": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.6.1.tgz",
+      "integrity": "sha512-Pc26IJbqgC9VG1u6VY/xrXXfxD33hnvxBnKrLlA2LJlyHII+BSrRoTPJgGYq7qZOu61itITFUnm6QbacwZ4H8Q==",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.6.1",
+        "@vueuse/shared": "10.6.1",
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.6.1.tgz",
+      "integrity": "sha512-qhdwPI65Bgcj23e5lpGfQsxcy0bMjCAsUGoXkJ7DsoeDUdasbZ2DBa4dinFCOER3lF4gwUv+UD2AlA11zdzMFw==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.6.1.tgz",
+      "integrity": "sha512-TECVDTIedFlL0NUfHWncf3zF9Gc4VfdxfQc8JFwoVZQmxpONhLxFrlm0eHQeidHj4rdTPL3KXJa0TZCk1wnc5Q==",
+      "dependencies": {
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.11.2",
@@ -986,6 +1076,26 @@
       "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-projection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
+      "dependencies": {
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg.js",
+        "geograticule": "bin/geograticule.js",
+        "geoproject": "bin/geoproject.js",
+        "geoquantize": "bin/geoquantize.js",
+        "geostitch": "bin/geostitch.js"
       },
       "engines": {
         "node": ">=12"

--- a/vacs-map-app/package.json
+++ b/vacs-map-app/package.json
@@ -13,8 +13,10 @@
   "dependencies": {
     "@turf/bbox": "^6.5.0",
     "@turf/helpers": "^6.5.0",
+    "@vueuse/core": "^10.6.1",
     "autoprefixer": "^10.4.16",
     "d3": "^7.8.5",
+    "d3-geo-projection": "^4.0.0",
     "mapbox-gl": "^3.0.0-rc.2",
     "pinia": "^2.1.7",
     "qs": "^6.11.2",

--- a/vacs-map-app/src/LandingPage.vue
+++ b/vacs-map-app/src/LandingPage.vue
@@ -13,7 +13,7 @@ The Vision for Adapted Crops and Soils (VACS) aims to foster more resilient food
         </button>
       </div>
       <div class="map-wrapper">
-        <MapContainerColor />
+        <MapHomepage />
       </div>
     </div>
   </LayoutOpen>
@@ -23,7 +23,7 @@ The Vision for Adapted Crops and Soils (VACS) aims to foster more resilient food
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import LayoutOpen from '@/components/layouts/LayoutOpen.vue';
-import MapContainerColor from '@/components/MapContainerColor.vue';
+import MapHomepage from './components/MapHomepage.vue';
 
 const router = useRouter();
 const navigate = () => router.push('/crops');
@@ -41,6 +41,7 @@ const navigate = () => router.push('/crops');
   display: flex;
   flex-direction: column;
   width: 55%;
+  justify-content: center;
 }
 
 .callout {

--- a/vacs-map-app/src/components/MapHomepage.vue
+++ b/vacs-map-app/src/components/MapHomepage.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="svg-wrapper" ref="wrapperRef">
+    <svg>
+      <g class="grid-cells">
+        <circle 
+          v-for="cell in gridCells"
+          class="grid-cell"
+          :key="cell.id"
+          :cx="cell.x"
+          :cy="cell.y"
+          :r="2"
+          :fill="getCellColor(cell.val)"
+        />
+      </g>
+    </svg>
+  </div>
+  
+</template>
+
+<script setup>
+import { storeToRefs } from 'pinia';
+import { useResizeObserver } from '@vueuse/core';
+import { ref, computed, onMounted, onBeforeUnmount} from 'vue';
+import { useFiltersStore } from '@/stores/filters';
+import { useCropYieldsStore } from '@/stores/cropYields';
+import { useGridStore } from '@/stores/grid';
+import * as d3 from 'd3';
+import { geoChamberlinAfrica } from 'd3-geo-projection';
+
+const filtersStore = useFiltersStore();
+const cropYieldsStore = useCropYieldsStore();
+const gridStore = useGridStore();
+
+const { data: cropYieldsData } = storeToRefs(cropYieldsStore);
+const { data: gridData } = storeToRefs(gridStore);
+const { availableCrops, availableModels } = storeToRefs(filtersStore);
+
+const wrapperRef = ref(null);
+const timer = ref(null);
+const selectedCropIndex = ref(0);
+const projection = ref(geoChamberlinAfrica());
+
+useResizeObserver(wrapperRef, ([entry]) => {
+  let w = entry.contentRect.width;
+  let h = entry.contentRect.height;
+
+  projection.value.translate([w/2, h/2]);
+  projection.value.scale(w * 0.75);
+})
+
+const selectedCrop = computed(() => availableCrops.value[selectedCropIndex.value]);
+const selectedColumn = computed(() => `yieldratio_${selectedCrop.value}_future_ssp370`);
+const selectedExtent = computed(() => cropYieldsStore.getExtent(selectedColumn.value));
+
+const gridCells = computed(() => {
+  if (!gridData.value || !cropYieldsData.value) return;
+  return gridData.value.map((cell, i) => {
+    return {
+      id: cell.id,
+      val: cropYieldsData.value[i][selectedColumn.value],
+      x: projection.value([cell.X, cell.Y])[0],
+      y: projection.value([cell.X, cell.Y])[1]
+    };
+  });
+});
+
+const getCellColor = (value) => {
+  if (!value) return 'transparent';
+
+  const scale = d3.scaleLinear()
+    .domain([selectedExtent.value[0], 0, selectedExtent.value[1]])
+    .range(["#FF8A00", "#D4D5A5", "#1CAC50"])
+    .clamp(true);
+  
+  return scale(value);
+}
+
+const updateGrid = () => {
+  if (selectedCropIndex.value === availableCrops.value.length - 1) {
+    selectedCropIndex.value = 0;
+  } else {
+    selectedCropIndex.value++;
+  }
+}
+
+onMounted(() => {
+  gridStore.load();
+  cropYieldsStore.load();
+
+  let w = wrapperRef.value.clientWidth;
+  let h = wrapperRef.value.clientHeight;
+  projection.value.translate([w/2, h/2]);
+  projection.value.scale(w * 0.75);
+  updateGrid();
+
+  timer.value = setInterval(() => {
+    updateGrid();
+  }, 5000)
+});
+
+
+onBeforeUnmount(() => {
+  clearInterval(timer.value);
+})
+
+</script>
+
+<style>
+
+.svg-wrapper {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+svg {
+  width: 100%;
+  height: 100%;
+}
+
+svg .grid-cell {
+  transition: fill 2.5s ease-in-out;
+}
+
+</style>


### PR DESCRIPTION
Closes #35 

The grid updates on window resize and for now is just cycling through all of the available crops in the data. Nothing too fancy yet, just letting css transitions fade the colors into each other over 2.5 seconds, crops switch every 5. It does match the diverging color scheme we use in the other maps so that should be consistent.

@kelsey-taylor happy to follow your lead on what other map features (if any) we want to add, and if you have any thoughts on how to improve the animation etc. this is just a first pass we can add to.

![Screenshot 2023-11-18 at 7 21 14 PM](https://github.com/earthrise-media/vacs-map/assets/25800091/ff9081f6-ec23-4954-a765-fadaf54dd7b0)
