### PR TITLE
Color extent across scenarios

### DIFF
--- a/vacs-map-app/src/MapExplorer.vue
+++ b/vacs-map-app/src/MapExplorer.vue
@@ -77,7 +77,7 @@ const mapExploreStore = useMapExploreStore();
 const { selectedMap } = storeToRefs(mapExploreStore);
 
 if (!selectedMap.value) {
-  selectedMap.value = availableMaps[0].id;
+  selectedMap.value = availableMaps[1].id;
 }
 
 const selectedMapComponent = computed(() => {

--- a/vacs-map-app/src/MapExplorer.vue
+++ b/vacs-map-app/src/MapExplorer.vue
@@ -18,6 +18,7 @@
 import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import MapContainerColor from '@/components/MapContainerColor.vue';
+import MapContainerColorAcrossScenarios from './components/MapContainerColorAcrossScenarios.vue';
 import MapContainerColorRadius from '@/components/MapContainerColorRadius.vue';
 import MapContainerNotFilled from '@/components/MapContainerNotFilled.vue';
 import MapContainerNotFilledTwoLayers from '@/components/MapContainerNotFilledTwoLayers.vue';
@@ -34,6 +35,11 @@ const availableMaps = [
     id: 'just-color',
     name: 'dynamic color',
     component: MapContainerColor,
+  },
+  {
+    id: 'color-across-scenarios',
+    name: 'color across scenarios',
+    component: MapContainerColorAcrossScenarios,
   },
   {
     id: 'color-and-radius-1',

--- a/vacs-map-app/src/assets/main.css
+++ b/vacs-map-app/src/assets/main.css
@@ -11,7 +11,7 @@
 
   --black: #272727;
   --white: #E1DCD5;
-  --dark-gray: #212121;
+  --dark-gray: #17191B;
 
   --page-horizontal-margin: 5rem;
 }

--- a/vacs-map-app/src/assets/main.css
+++ b/vacs-map-app/src/assets/main.css
@@ -11,7 +11,7 @@
 
   --black: #272727;
   --white: #E1DCD5;
-  --dark-gray: #404040;
+  --dark-gray: #212121;
 
   --page-horizontal-margin: 5rem;
 }

--- a/vacs-map-app/src/components/DistributionPlot.vue
+++ b/vacs-map-app/src/components/DistributionPlot.vue
@@ -93,7 +93,7 @@ const getCellColor = (value) => {
   if (!value) return 'transparent';
   const scale = d3.scaleLinear()
     .domain([metaExtent.value[0], 0, metaExtent.value[1]])
-    .range(["#FF8A00", "#D4D5A5", "#1CAC50"])
+    .range(["#FFA31A", "#424242", "#13F364"])
     .clamp(true);
 
   return scale(value);

--- a/vacs-map-app/src/components/DistributionPlot.vue
+++ b/vacs-map-app/src/components/DistributionPlot.vue
@@ -23,6 +23,7 @@ import { computed, toRefs, ref, onMounted } from 'vue';
 import { useFiltersStore } from '@/stores/filters';
 import { useCropYieldsStore } from '@/stores/cropYields'; 
 import { storeToRefs } from 'pinia';
+import { divergingScheme } from '@/utils/colors';
 
 const props = defineProps({
   scenario: {
@@ -93,7 +94,7 @@ const getCellColor = (value) => {
   if (!value) return 'transparent';
   const scale = d3.scaleLinear()
     .domain([metaExtent.value[0], 0, metaExtent.value[1]])
-    .range(["#FFA31A", "#424242", "#13F364"])
+    .range([divergingScheme.min, divergingScheme.center, divergingScheme.max])
     .clamp(true);
 
   return scale(value);

--- a/vacs-map-app/src/components/DistributionPlot.vue
+++ b/vacs-map-app/src/components/DistributionPlot.vue
@@ -23,6 +23,7 @@ import { computed, toRefs, ref, onMounted } from 'vue';
 import { useFiltersStore } from '@/stores/filters';
 import { useCropYieldsStore } from '@/stores/cropYields'; 
 import { storeToRefs } from 'pinia';
+import { divergingScheme } from '@/utils/colors';
 
 const props = defineProps({
   scenario: {
@@ -103,7 +104,7 @@ const getCellColor = (value) => {
   if (!value) return 'transparent';
   const scale = d3.scaleLinear()
     .domain([colorExtent.value[0], 0, colorExtent.value[1]])
-    .range(["#FF8A00", "#D4D5A5", "#1CAC50"])
+    .range([divergingScheme.min, divergingScheme.center, divergingScheme.max])
     .clamp(true);
 
   return scale(value);

--- a/vacs-map-app/src/components/DistributionPlot.vue
+++ b/vacs-map-app/src/components/DistributionPlot.vue
@@ -23,7 +23,6 @@ import { computed, toRefs, ref, onMounted } from 'vue';
 import { useFiltersStore } from '@/stores/filters';
 import { useCropYieldsStore } from '@/stores/cropYields'; 
 import { storeToRefs } from 'pinia';
-import { divergingScheme } from '@/utils/colors';
 
 const props = defineProps({
   scenario: {
@@ -67,6 +66,16 @@ const metaExtent = computed(() => {
   return [d3.min(extents.map(d => d[0])), d3.min(extents.map(d => d[1]))];
 })
 
+const colorExtent = computed(() => {
+  // want to get extent across all scenarios and included crops so that comparisons are more useful
+  const extents = []
+  availableModels.value.forEach(s => {
+    const column = [selectedMetric.value, selectedCrop.value, s].join("_");
+    extents.push(cropYieldsStore.getExtent(column))
+  })
+  return [d3.min(extents.map(d => d[0])), d3.min(extents.map(d => d[1]))];
+})
+
 const gridCells = computed(() => {
   if (!cropYieldsData.value) return;
   return cropYieldsData.value.map((row) => {
@@ -93,8 +102,8 @@ const xScale = computed(() => {
 const getCellColor = (value) => {
   if (!value) return 'transparent';
   const scale = d3.scaleLinear()
-    .domain([metaExtent.value[0], 0, metaExtent.value[1]])
-    .range([divergingScheme.min, divergingScheme.center, divergingScheme.max])
+    .domain([colorExtent.value[0], 0, colorExtent.value[1]])
+    .range(["#FF8A00", "#D4D5A5", "#1CAC50"])
     .clamp(true);
 
   return scale(value);

--- a/vacs-map-app/src/components/GridOverlay.vue
+++ b/vacs-map-app/src/components/GridOverlay.vue
@@ -3,6 +3,7 @@
 <script setup>
 import * as d3 from 'd3';
 import { computed, toRefs, watch } from 'vue';
+import { divergingScheme } from '@/utils/colors';
 
 const props = defineProps({
   id: {
@@ -213,7 +214,7 @@ const getCircleColorDiverging = (extent, center) => {
 
     // const interpolator = d3.interpolatePiYG;
 
-    const interpolator = d3.interpolateHsl("#FFA31A", "#13F364");
+    const interpolator = d3.interpolateHsl(divergingScheme.min, divergingScheme.max);
 
     return interpolator(value);
   };
@@ -226,7 +227,7 @@ const getCircleColorDiverging = (extent, center) => {
       ['linear'],
       ['get', colorColumn.value],
       min, getColor(0),
-      center, "#424242",
+      center, divergingScheme.center,
       max, getColor(1),
     ],
     'transparent',

--- a/vacs-map-app/src/components/GridOverlay.vue
+++ b/vacs-map-app/src/components/GridOverlay.vue
@@ -94,6 +94,7 @@ const addLayer = () => {
       'circle-stroke-opacity': fill.value ? 0 : 0.8,
       'circle-opacity': 1,
       'circle-color': getCircleFillColor(),
+      'circle-blur': 0.5
     }
   }, 'country-label-filter');
 
@@ -212,7 +213,7 @@ const getCircleColorDiverging = (extent, center) => {
 
     // const interpolator = d3.interpolatePiYG;
 
-    const interpolator = d3.interpolateHsl("#FF8A00", "#1CAC50");
+    const interpolator = d3.interpolateHsl("#FFA31A", "#13F364");
 
     return interpolator(value);
   };
@@ -225,7 +226,7 @@ const getCircleColorDiverging = (extent, center) => {
       ['linear'],
       ['get', colorColumn.value],
       min, getColor(0),
-      center, "#D4D5A5",
+      center, "#424242",
       max, getColor(1),
     ],
     'transparent',

--- a/vacs-map-app/src/components/MapContainerColorAcrossScenarios.vue
+++ b/vacs-map-app/src/components/MapContainerColorAcrossScenarios.vue
@@ -1,0 +1,88 @@
+<template>
+  <BaseMap>
+    <template v-slot="{ map, mapReady }">
+      <GridSource :id="sourceId" :map="map" :mapReady="mapReady" />
+      <GridOverlay
+        id="grid-layer-1"
+        :color-column="selectedColumn"
+        :color-column-extent="selectedExtent"
+        :color-column-quintiles="selectedColumnQuintiles"
+        :color-diverging="selectedMetric === 'yieldratio'"
+        :sourceId="sourceId"
+        :map="map"
+        :mapReady="mapReady"
+      />
+    </template>
+  </BaseMap>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import BaseMap from '@/components/BaseMap.vue';
+import { useFiltersStore } from '@/stores/filters';
+import { useCropYieldsStore } from '@/stores/cropYields';
+import GridSource from './GridSource.vue';
+import GridOverlay from './GridOverlay.vue';
+import * as d3 from 'd3';
+
+const sourceId = 'cropGrid';
+const cropYieldsStore = useCropYieldsStore();
+const filtersStore = useFiltersStore();
+
+const {
+  selectedCrop,
+  selectedMetric,
+  selectedModel,
+  availableModels
+} = storeToRefs(filtersStore);
+
+
+const selectedColumn = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
+    return null;
+  }
+
+  return [
+    selectedMetric.value,
+    selectedCrop.value,
+    selectedModel.value,
+  ].join('_');
+});
+
+// to get extent across scenarios
+const scenarios = computed(() => {
+  if (selectedMetric.value === 'yieldratio') {
+    return availableModels.value.filter(d => d.startsWith('future'))
+  } else {
+    return availableModels.value;
+  }
+});
+
+// to get extent across scenarios
+const columns = computed(() => {
+  if (!selectedMetric.value || !selectedCrop.value || !scenarios.value.length) {
+    return null;
+  }
+  return scenarios.value.map(s => [selectedMetric.value, selectedCrop.value, s].join('_'));
+});
+
+const selectedExtent = computed(() => {
+  if (!columns.value.length) return null;
+
+  const extents = columns.value.map(c => cropYieldsStore.getExtent(c));
+
+  return [
+    d3.min(extents, extent => d3.min(extent)),
+    d3.max(extents, extent => d3.max(extent))
+  ];
+});
+
+
+const selectedColumnQuintiles = computed(() => {
+  if (!selectedColumn.value) return null;
+  return cropYieldsStore.getQuintiles(selectedColumn.value);
+});
+</script>
+
+<style scoped></style>

--- a/vacs-map-app/src/components/MapHomepage.vue
+++ b/vacs-map-app/src/components/MapHomepage.vue
@@ -75,7 +75,7 @@ const getCellColor = (value) => {
 
   const scale = d3.scaleLinear()
     .domain([selectedExtent.value[0], 0, selectedExtent.value[1]])
-    .range(["#FF8A00", "#D4D5A5", "#1CAC50"])
+    .range(["#FFA31A", "#424242", "#13F364"])
     .clamp(true);
   
   return scale(value);

--- a/vacs-map-app/src/components/MapHomepage.vue
+++ b/vacs-map-app/src/components/MapHomepage.vue
@@ -40,16 +40,34 @@ const width = ref(0);
 const height = ref(0);
 const timer = ref(null);
 const selectedCropIndex = ref(0);
+const selectedScenarioIndex = ref(0);
+const switchCrop = ref(false);
 
 useResizeObserver(wrapperRef, ([entry]) => {
   width.value = entry.contentRect.width;
   height.value = entry.contentRect.height;
 });
 
-const selectedCrop = computed(() => availableCrops.value[selectedCropIndex.value]);
-const selectedColumn = computed(() => `yieldratio_${selectedCrop.value}_future_ssp370`);
-const selectedExtent = computed(() => cropYieldsStore.getExtent(selectedColumn.value));
+const futureScenarios = computed(() => availableModels.value.filter(d => d.startsWith('future')));
 
+const selectedCrop = computed(() => availableCrops.value[selectedCropIndex.value]);
+const selectedScenario = computed(() => futureScenarios.value[selectedScenarioIndex.value]);
+const selectedColumn = computed(() => `yieldratio_${selectedCrop.value}_${selectedScenario.value}`);
+
+const scenarioColumns = computed(() => {
+  return availableModels.value.filter(d => d.startsWith('future')).map(
+    d => `yieldratio_${selectedCrop.value}_${d}`
+  )
+})
+
+const selectedExtent = computed(() => {
+  const extents = scenarioColumns.value.map(d => cropYieldsStore.getExtent(d))
+  return [
+    d3.min(extents, extent => d3.min(extent)),
+    d3.max(extents, extent => d3.max(extent))
+  ];
+})
+  
 
 // this handles the projection, with translation and scale based on window size (responsive)
 const projection = computed(() => {
@@ -83,10 +101,20 @@ const getCellColor = (value) => {
 };
 
 const updateGrid = () => {
-  if (selectedCropIndex.value === availableCrops.value.length - 1) {
-    selectedCropIndex.value = 0;
+  if (switchCrop.value) {
+    if (selectedCropIndex.value === availableCrops.value.length - 1) {
+      selectedCropIndex.value = 0;
+    } else {
+      selectedCropIndex.value++;
+    }
+    switchCrop.value = false;
   } else {
-    selectedCropIndex.value++;
+    if (selectedScenarioIndex.value === futureScenarios.value.length - 1) {
+      selectedScenarioIndex.value = 0;
+    } else {
+      selectedScenarioIndex.value++;
+    }
+    switchCrop.value = true;
   }
 };
 

--- a/vacs-map-app/src/components/MapHomepage.vue
+++ b/vacs-map-app/src/components/MapHomepage.vue
@@ -25,6 +25,7 @@ import { useCropYieldsStore } from '@/stores/cropYields';
 import { useGridStore } from '@/stores/grid';
 import * as d3 from 'd3';
 import { geoChamberlinAfrica } from 'd3-geo-projection';
+import { divergingScheme } from '../utils/colors';
 
 const filtersStore = useFiltersStore();
 const cropYieldsStore = useCropYieldsStore();
@@ -75,7 +76,7 @@ const getCellColor = (value) => {
 
   const scale = d3.scaleLinear()
     .domain([selectedExtent.value[0], 0, selectedExtent.value[1]])
-    .range(["#FFA31A", "#424242", "#13F364"])
+    .range([divergingScheme.min, divergingScheme.center, divergingScheme.max])
     .clamp(true);
   
   return scale(value);

--- a/vacs-map-app/src/utils/colors.js
+++ b/vacs-map-app/src/utils/colors.js
@@ -1,0 +1,6 @@
+
+export const divergingScheme = {
+  min: "#FFA31A",
+  center: "#424242",
+  max: "#13F364",
+}


### PR DESCRIPTION
Closes #41 .

This adds a new map component (keeps the old ones also) that uses the proposed new color extent calculation. I think we should keep this specific to map components for now, so for other maps where we want to do this we should copy the extent code from `MapContainerColorAcrossScenarios.vue` (which was just added).

@kelsey-taylor the change is pretty subtle but I think it definitely makes sense. I wouldn't say its even overwhelmingly more green for the low emissions scenario. For some crops its more green in higher emissions!

I also updated the home screen to cycle through scenarios before going onto the next crop which I kinda like

Going to wait until #42 is merged because I brought those colors into this PR as well.