### PR TITLE
Add crop fingerprint chart

### DIFF
--- a/vacs-map-app/src/App.vue
+++ b/vacs-map-app/src/App.vue
@@ -8,14 +8,14 @@
 import { onMounted } from 'vue'
 import { RouterView } from 'vue-router'
 import { useCropYieldsStore } from '@/stores/cropYields'
-import { useCropInformationStore } from './stores/cropInformation';
+import { useCropInformationStore } from './stores/cropInformation'
 
 const cropYieldsStore = useCropYieldsStore()
-const cropInformationStore = useCropInformationStore();
+const cropInformationStore = useCropInformationStore()
 
 onMounted(() => {
-  cropYieldsStore.load();
-  cropInformationStore.load();
+  cropYieldsStore.load()
+  cropInformationStore.load()
 })
 </script>
 

--- a/vacs-map-app/src/MapExplorer.vue
+++ b/vacs-map-app/src/MapExplorer.vue
@@ -15,20 +15,20 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
-import { storeToRefs } from 'pinia';
-import MapContainerColor from '@/components/MapContainerColor.vue';
-import MapContainerColorAcrossScenarios from './components/MapContainerColorAcrossScenarios.vue';
-import MapContainerColorRadius from '@/components/MapContainerColorRadius.vue';
-import MapContainerNotFilled from '@/components/MapContainerNotFilled.vue';
-import MapContainerNotFilledTwoLayers from '@/components/MapContainerNotFilledTwoLayers.vue';
-import MapContainerColorAfricanUnion from '@/components/MapContainerColorAfricanUnion.vue';
-import MapContainerColorSandSoil from '@/components/MapContainerColorSandSoil.vue';
-import MapContainerColorSoil from '@/components/MapContainerColorSoil.vue';
-import MapContainerColorSand from '@/components/MapContainerColorSand.vue';
-import { useMapExploreStore } from '@/stores/mapExplore';
-import LayoutOverview from './components/layouts/LayoutOverview.vue';
-import ExploreSidebar from './components/ExploreSidebar.vue';
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import MapContainerColor from '@/components/MapContainerColor.vue'
+import MapContainerColorAcrossScenarios from './components/MapContainerColorAcrossScenarios.vue'
+import MapContainerColorRadius from '@/components/MapContainerColorRadius.vue'
+import MapContainerNotFilled from '@/components/MapContainerNotFilled.vue'
+import MapContainerNotFilledTwoLayers from '@/components/MapContainerNotFilledTwoLayers.vue'
+import MapContainerColorAfricanUnion from '@/components/MapContainerColorAfricanUnion.vue'
+import MapContainerColorSandSoil from '@/components/MapContainerColorSandSoil.vue'
+import MapContainerColorSoil from '@/components/MapContainerColorSoil.vue'
+import MapContainerColorSand from '@/components/MapContainerColorSand.vue'
+import { useMapExploreStore } from '@/stores/mapExplore'
+import LayoutOverview from './components/layouts/LayoutOverview.vue'
+import ExploreSidebar from './components/ExploreSidebar.vue'
 
 const availableMaps = [
   {
@@ -39,7 +39,7 @@ const availableMaps = [
   {
     id: 'color-across-scenarios',
     name: 'color across scenarios',
-    component: MapContainerColorAcrossScenarios,
+    component: MapContainerColorAcrossScenarios
   },
   {
     id: 'color-and-radius-1',
@@ -82,7 +82,7 @@ const mapExploreStore = useMapExploreStore()
 const { selectedMap } = storeToRefs(mapExploreStore)
 
 if (!selectedMap.value) {
-  selectedMap.value = availableMaps[1].id;
+  selectedMap.value = availableMaps[1].id
 }
 
 const selectedMapComponent = computed(() => {

--- a/vacs-map-app/src/components/CropCards.vue
+++ b/vacs-map-app/src/components/CropCards.vue
@@ -24,31 +24,26 @@ import { useFiltersStore } from '@/stores/filters'
 import { useCropInformationStore } from '../stores/cropInformation'
 import CardWrapper from './CardWrapper.vue'
 
-const router = useRouter();
-const filtersStore = useFiltersStore();
-const cropInformationStore = useCropInformationStore();
-const {  
-  selectedCrop, 
-  selectedModel,
-  selectedCropGroup,
-  cropSortBy,
-  cropSortOrder,
-} = storeToRefs(filtersStore)
-const { data: cropInformation } = storeToRefs(cropInformationStore);
+const router = useRouter()
+const filtersStore = useFiltersStore()
+const cropInformationStore = useCropInformationStore()
+const { selectedCrop, selectedModel, selectedCropGroup, cropSortBy, cropSortOrder } =
+  storeToRefs(filtersStore)
+const { data: cropInformation } = storeToRefs(cropInformationStore)
 
 const filteredCrops = computed(() => {
-  if (!selectedCropGroup.value) return cropInformation.value;
-  return cropInformation.value.filter(d => d.crop_group === selectedCropGroup.value);
+  if (!selectedCropGroup.value) return cropInformation.value
+  return cropInformation.value.filter((d) => d.crop_group === selectedCropGroup.value)
 })
 
 const sortedCrops = computed(() => {
-  if (!cropSortBy.value) return filteredCrops.value;
-  return [...filteredCrops.value].sort(
-    (a, b) => d3[cropSortOrder.value](
-      a.indicators.nutritional[cropSortBy.value], 
+  if (!cropSortBy.value) return filteredCrops.value
+  return [...filteredCrops.value].sort((a, b) =>
+    d3[cropSortOrder.value](
+      a.indicators.nutritional[cropSortBy.value],
       b.indicators.nutritional[cropSortBy.value]
     )
-  );
+  )
 })
 
 const navigate = (crop) => {
@@ -57,7 +52,7 @@ const navigate = (crop) => {
 }
 
 const getUrl = (crop) => {
-  return new URL(`../assets/img/minimaps/${crop}_${selectedModel.value}.svg`, import.meta.url).href;
+  return new URL(`../assets/img/minimaps/${crop}_${selectedModel.value}.svg`, import.meta.url).href
 }
 </script>
 

--- a/vacs-map-app/src/components/CropFilters.vue
+++ b/vacs-map-app/src/components/CropFilters.vue
@@ -14,7 +14,7 @@
     </div>
 
     <div class="crop-groups">
-      <div 
+      <div
         :class="{
           selected: selectedCropGroup === ''
         }"
@@ -37,21 +37,17 @@
     <div class="sort-by">
       <div class="sort-order">
         <div class="sort-order-option">
-          <input type="radio" v-model="cropSortOrder" id="descending" value="descending">
+          <input type="radio" v-model="cropSortOrder" id="descending" value="descending" />
           <label for="descending">High to low</label>
         </div>
         <div class="sort-order-option">
-          <input type="radio" v-model="cropSortOrder" id="ascending" value="ascending">
+          <input type="radio" v-model="cropSortOrder" id="ascending" value="ascending" />
           <label for="ascending">Low to high</label>
         </div>
       </div>
 
       <select v-model="cropSortBy">
-        <option 
-          v-for="option in cropSortByOptions" 
-          :key="option"
-          :value="option"
-        >
+        <option v-for="option in cropSortByOptions" :key="option" :value="option">
           {{ option }}
         </option>
       </select>
@@ -64,16 +60,16 @@ import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useFiltersStore } from '@/stores/filters'
 
-const filtersStore = useFiltersStore();
-const { 
-  availableModels, 
-  selectedModel, 
-  availableCropGroups, 
+const filtersStore = useFiltersStore()
+const {
+  availableModels,
+  selectedModel,
+  availableCropGroups,
   selectedCropGroup,
   cropSortByOptions,
   cropSortBy,
-  cropSortOrder,
-} = storeToRefs(filtersStore);
+  cropSortOrder
+} = storeToRefs(filtersStore)
 
 const futureScenarios = computed(() => {
   return availableModels.value.filter((d) => d.startsWith('future'))
@@ -86,7 +82,8 @@ const futureScenarios = computed(() => {
   gap: 2rem;
 }
 
-.scenarios, .crop-groups {
+.scenarios,
+.crop-groups {
   display: flex;
   flex-direction: row;
   gap: 1rem;
@@ -117,7 +114,8 @@ const futureScenarios = computed(() => {
   gap: 0.25rem;
 }
 
-.sort-order label, .sort-order input {
+.sort-order label,
+.sort-order input {
   cursor: pointer;
 }
 </style>

--- a/vacs-map-app/src/components/CropFingerprint.vue
+++ b/vacs-map-app/src/components/CropFingerprint.vue
@@ -10,10 +10,10 @@
               :fill="fingerprintScheme[indicator.category]"
               :d="arc(indicator)"
               :class="{
-                highlighted: hovered === indicator.key,
-                unhighlighted: hovered && hovered !== indicator.key
+                highlighted: hovered?.key === indicator.key,
+                unhighlighted: hovered && hovered.key !== indicator.key
               }"
-              @mouseenter="hovered = indicator.key"
+              @mouseenter="hovered = indicator"
               @mouseleave="hovered = null"
             />
           </g>
@@ -40,8 +40,8 @@
                 :stroke-width="1"
                 :d="arc(indicator)"
                 :class="{
-                  highlighted: hovered === indicator.key,
-                  unhighlighted: hovered && hovered !== indicator.key
+                  highlighted: hovered?.key === indicator.key,
+                  unhighlighted: hovered && hovered.key !== indicator.key
                 }"
               />
             </g>
@@ -50,16 +50,15 @@
       </svg>
     </div>
     <div class="legend">
-      <div class="metric-label" :class="{ active: hovered }">
-        {{ hovered ? hovered : 'no metric selected' }}
-      </div>
-      <div class="category-labels">
-        <span
-          v-for="cat in indicatorCategories"
-          :key="cat"
-          :style="{ color: fingerprintScheme[cat] }"
+      <div v-if="hovered !== null" class="hovered-label">
+        <span class="category-label" :style="{ background: fingerprintScheme[hovered.category] }">
+          {{ hovered.category }}</span
         >
-          {{ cat }}
+        <span class="metric-label"> {{ hovered.key }} </span>
+      </div>
+      <div class="benchmark-message">
+        <span v-if="showBenchmark">
+          *Outlines show characteristics of benchmark crop {{ benchmarkCropObject.label }}
         </span>
       </div>
     </div>
@@ -69,7 +68,7 @@
 <script setup>
 import * as d3 from 'd3'
 import { useResizeObserver } from '@vueuse/core'
-import { computed, toRefs, ref, onMounted } from 'vue'
+import { computed, toRefs, ref } from 'vue'
 import { useCropInformationStore } from '../stores/cropInformation'
 import { storeToRefs } from 'pinia'
 import { fingerprintScheme } from '../utils/colors'
@@ -116,6 +115,7 @@ const benchmarkIndicators = computed(() => {
 })
 
 const showBenchmark = computed(() => {
+  if (!benchmarkCropObject.value) return false
   return benchmarkCropObject.value !== selectedCropObject.value
 })
 
@@ -174,11 +174,13 @@ const arc = computed(() => {
 
 <style scoped>
 .fingerprint-wrapper {
+  position: relative;
   height: 100%;
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  padding-bottom: 3rem;
 }
 .svg-wrapper {
   height: 100%;
@@ -203,23 +205,37 @@ svg {
 }
 
 .legend {
+  position: absolute;
+  bottom: 0;
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
+  height: 3rem;
+  color: var(--white);
 }
 
-.category-labels {
+.hovered-label {
   display: flex;
   flex-direction: row;
-  justify-content: space-evenly;
-  text-transform: uppercase;
+  gap: 0.5rem;
+}
+
+.category-label {
+  color: var(--black);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 1px 4px;
+  text-transform: capitalize;
 }
 
 .metric-label {
-  text-align: center;
-  color: var(--dark-gray);
+  color: var(--white);
+  font-size: 1rem;
 }
 
-.metric-label.active {
-  color: var(--white);
+.benchmark-message {
+  font-size: 0.8125rem;
+  font-style: italic;
+  font-weight: 300;
 }
 </style>

--- a/vacs-map-app/src/components/CropFingerprint.vue
+++ b/vacs-map-app/src/components/CropFingerprint.vue
@@ -2,9 +2,9 @@
   <div class="fingerprint-wrapper">
     <div class="svg-wrapper" ref="wrapperRef">
       <svg>
-        <g class="chart" :transform="`translate(${width/2}, ${height/2})`">
+        <g class="chart" :transform="`translate(${width / 2}, ${height / 2})`">
           <g class="selected-crop-plots">
-            <path 
+            <path
               v-for="indicator in selectedIndicators"
               :key="indicator.key"
               :fill="fingerprintScheme[indicator.category]"
@@ -19,28 +19,20 @@
           </g>
 
           <g class="chart-overlay">
-            <g 
-              class="axes"
-              fill="none"
-              stroke="#17191b"
-              >
-              <circle 
-                v-for="d in d3.range(11)" 
-                :key="d"
-                :r="y(d)"
-              />
+            <g class="axes" fill="none" stroke="#17191b">
+              <circle v-for="d in d3.range(11)" :key="d" :r="y(d)" />
 
-              <line 
-                v-for="(metric) in indicatorMetrics"
+              <line
+                v-for="metric in indicatorMetrics"
                 :key="metric"
-                :transform="`rotate(${xDegrees(metric) + xDegrees.bandwidth()/2})`"
+                :transform="`rotate(${xDegrees(metric) + xDegrees.bandwidth() / 2})`"
                 :x1="0"
                 :x2="y(10)"
               />
             </g>
 
             <g v-if="showBenchmark">
-              <path 
+              <path
                 v-for="indicator in benchmarkIndicators"
                 :key="indicator.key"
                 fill="none"
@@ -62,26 +54,25 @@
         {{ hovered ? hovered : 'no metric selected' }}
       </div>
       <div class="category-labels">
-        <span 
-          v-for="cat in indicatorCategories" 
+        <span
+          v-for="cat in indicatorCategories"
           :key="cat"
-          :style="{color: fingerprintScheme[cat]}"
-          >
+          :style="{ color: fingerprintScheme[cat] }"
+        >
           {{ cat }}
         </span>
       </div>
     </div>
   </div>
-
 </template>
 
 <script setup>
 import * as d3 from 'd3'
 import { useResizeObserver } from '@vueuse/core'
 import { computed, toRefs, ref, onMounted } from 'vue'
-import { useCropInformationStore } from '../stores/cropInformation';
-import { storeToRefs } from 'pinia';
-import { fingerprintScheme } from '../utils/colors';
+import { useCropInformationStore } from '../stores/cropInformation'
+import { storeToRefs } from 'pinia'
+import { fingerprintScheme } from '../utils/colors'
 
 const props = defineProps({
   cropId: {
@@ -90,7 +81,7 @@ const props = defineProps({
   }
 })
 const { cropId } = toRefs(props)
-const hovered = ref(null);
+const hovered = ref(null)
 
 const wrapperRef = ref(null)
 const width = ref(0)
@@ -101,38 +92,38 @@ useResizeObserver(wrapperRef, ([entry]) => {
   height.value = entry.contentRect.height
 })
 
-const cropInformationStore = useCropInformationStore();
-const { data: cropInformation } = storeToRefs(cropInformationStore);
+const cropInformationStore = useCropInformationStore()
+const { data: cropInformation } = storeToRefs(cropInformationStore)
 
 const selectedCropObject = computed(() => {
-  if (!cropInformation.value) return null;
-  return cropInformation.value.find(d => d.id === cropId.value);
+  if (!cropInformation.value) return null
+  return cropInformation.value.find((d) => d.id === cropId.value)
 })
 
 const selectedIndicators = computed(() => {
-  return getIndicators(selectedCropObject.value);
+  return getIndicators(selectedCropObject.value)
 })
 
 const benchmarkCropObject = computed(() => {
-  if (!cropInformation.value) return null;
-  return cropInformation.value.find(d => 
-    d.crop_group === selectedCropObject.value.crop_group && d.benchmark
-  );
+  if (!cropInformation.value) return null
+  return cropInformation.value.find(
+    (d) => d.crop_group === selectedCropObject.value.crop_group && d.benchmark
+  )
 })
 
 const benchmarkIndicators = computed(() => {
-  return getIndicators(benchmarkCropObject.value);
+  return getIndicators(benchmarkCropObject.value)
 })
 
 const showBenchmark = computed(() => {
-  return benchmarkCropObject.value !== selectedCropObject.value;
+  return benchmarkCropObject.value !== selectedCropObject.value
 })
 
 const getIndicators = (crop) => {
-  if (!crop) return [];
-  const arr = [];
-  Object.entries(crop.indicators).forEach(cat => {
-    const category = cat[0];
+  if (!crop) return []
+  const arr = []
+  Object.entries(crop.indicators).forEach((cat) => {
+    const category = cat[0]
     Object.entries(cat[1]).forEach(([k, v]) => {
       arr.push({
         key: k,
@@ -140,52 +131,48 @@ const getIndicators = (crop) => {
         category
       })
     })
-  });
-  return arr;
-};
+  })
+  return arr
+}
 
 const indicatorCategories = computed(() => {
-  return Object.keys(selectedCropObject.value.indicators);
+  return Object.keys(selectedCropObject.value.indicators)
 })
 
 const indicatorMetrics = computed(() => {
-  return selectedIndicators.value.map(d => d.key);
+  return selectedIndicators.value.map((d) => d.key)
 })
 
 const radius = computed(() => {
-  return Math.min(width.value, height.value) / 2;
+  return Math.min(width.value, height.value) / 2
 })
 
 const x = computed(() => {
-  return d3.scaleBand()
+  return d3
+    .scaleBand()
     .domain(indicatorMetrics.value)
     .range([0, Math.PI * 2])
 })
 
 const xDegrees = computed(() => {
-  return d3.scaleBand()
-    .domain(indicatorMetrics.value)
-    .range([0, 360])
+  return d3.scaleBand().domain(indicatorMetrics.value).range([0, 360])
 })
 
 const y = computed(() => {
-  return d3.scaleLinear()
-    .domain([0, 10])
-    .range([0, radius.value])
+  return d3.scaleLinear().domain([0, 10]).range([0, radius.value])
 })
 
 const arc = computed(() => {
-  return d3.arc()
+  return d3
+    .arc()
     .innerRadius(y.value(0))
-    .outerRadius(d => y.value(d.value))
-    .startAngle(d => x.value(d.key))
-    .endAngle(d => x.value(d.key) + x.value.bandwidth())
+    .outerRadius((d) => y.value(d.value))
+    .startAngle((d) => x.value(d.key))
+    .endAngle((d) => x.value(d.key) + x.value.bandwidth())
 })
-
 </script>
 
 <style scoped>
-
 .fingerprint-wrapper {
   height: 100%;
   width: 100%;

--- a/vacs-map-app/src/components/CropFingerprint.vue
+++ b/vacs-map-app/src/components/CropFingerprint.vue
@@ -1,0 +1,238 @@
+<template>
+  <div class="fingerprint-wrapper">
+    <div class="svg-wrapper" ref="wrapperRef">
+      <svg>
+        <g class="chart" :transform="`translate(${width/2}, ${height/2})`">
+          <g class="selected-crop-plots">
+            <path 
+              v-for="indicator in selectedIndicators"
+              :key="indicator.key"
+              :fill="fingerprintScheme[indicator.category]"
+              :d="arc(indicator)"
+              :class="{
+                highlighted: hovered === indicator.key,
+                unhighlighted: hovered && hovered !== indicator.key
+              }"
+              @mouseenter="hovered = indicator.key"
+              @mouseleave="hovered = null"
+            />
+          </g>
+
+          <g class="chart-overlay">
+            <g 
+              class="axes"
+              fill="none"
+              stroke="#17191b"
+              >
+              <circle 
+                v-for="d in d3.range(11)" 
+                :key="d"
+                :r="y(d)"
+              />
+
+              <line 
+                v-for="(metric) in indicatorMetrics"
+                :key="metric"
+                :transform="`rotate(${xDegrees(metric) + xDegrees.bandwidth()/2})`"
+                :x1="0"
+                :x2="y(10)"
+              />
+            </g>
+
+            <g v-if="showBenchmark">
+              <path 
+                v-for="indicator in benchmarkIndicators"
+                :key="indicator.key"
+                fill="none"
+                stroke="#e1dcd5"
+                :stroke-width="1"
+                :d="arc(indicator)"
+                :class="{
+                  highlighted: hovered === indicator.key,
+                  unhighlighted: hovered && hovered !== indicator.key
+                }"
+              />
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+    <div class="legend">
+      <div class="metric-label" :class="{ active: hovered }">
+        {{ hovered ? hovered : 'no metric selected' }}
+      </div>
+      <div class="category-labels">
+        <span 
+          v-for="cat in indicatorCategories" 
+          :key="cat"
+          :style="{color: fingerprintScheme[cat]}"
+          >
+          {{ cat }}
+        </span>
+      </div>
+    </div>
+  </div>
+
+</template>
+
+<script setup>
+import * as d3 from 'd3'
+import { useResizeObserver } from '@vueuse/core'
+import { computed, toRefs, ref, onMounted } from 'vue'
+import { useCropInformationStore } from '../stores/cropInformation';
+import { storeToRefs } from 'pinia';
+import { fingerprintScheme } from '../utils/colors';
+
+const props = defineProps({
+  cropId: {
+    type: String,
+    default: ''
+  }
+})
+const { cropId } = toRefs(props)
+const hovered = ref(null);
+
+const wrapperRef = ref(null)
+const width = ref(0)
+const height = ref(0)
+
+useResizeObserver(wrapperRef, ([entry]) => {
+  width.value = entry.contentRect.width
+  height.value = entry.contentRect.height
+})
+
+const cropInformationStore = useCropInformationStore();
+const { data: cropInformation } = storeToRefs(cropInformationStore);
+
+const selectedCropObject = computed(() => {
+  if (!cropInformation.value) return null;
+  return cropInformation.value.find(d => d.id === cropId.value);
+})
+
+const selectedIndicators = computed(() => {
+  return getIndicators(selectedCropObject.value);
+})
+
+const benchmarkCropObject = computed(() => {
+  if (!cropInformation.value) return null;
+  return cropInformation.value.find(d => 
+    d.crop_group === selectedCropObject.value.crop_group && d.benchmark
+  );
+})
+
+const benchmarkIndicators = computed(() => {
+  return getIndicators(benchmarkCropObject.value);
+})
+
+const showBenchmark = computed(() => {
+  return benchmarkCropObject.value !== selectedCropObject.value;
+})
+
+const getIndicators = (crop) => {
+  if (!crop) return [];
+  const arr = [];
+  Object.entries(crop.indicators).forEach(cat => {
+    const category = cat[0];
+    Object.entries(cat[1]).forEach(([k, v]) => {
+      arr.push({
+        key: k,
+        value: v,
+        category
+      })
+    })
+  });
+  return arr;
+};
+
+const indicatorCategories = computed(() => {
+  return Object.keys(selectedCropObject.value.indicators);
+})
+
+const indicatorMetrics = computed(() => {
+  return selectedIndicators.value.map(d => d.key);
+})
+
+const radius = computed(() => {
+  return Math.min(width.value, height.value) / 2;
+})
+
+const x = computed(() => {
+  return d3.scaleBand()
+    .domain(indicatorMetrics.value)
+    .range([0, Math.PI * 2])
+})
+
+const xDegrees = computed(() => {
+  return d3.scaleBand()
+    .domain(indicatorMetrics.value)
+    .range([0, 360])
+})
+
+const y = computed(() => {
+  return d3.scaleLinear()
+    .domain([0, 10])
+    .range([0, radius.value])
+})
+
+const arc = computed(() => {
+  return d3.arc()
+    .innerRadius(y.value(0))
+    .outerRadius(d => y.value(d.value))
+    .startAngle(d => x.value(d.key))
+    .endAngle(d => x.value(d.key) + x.value.bandwidth())
+})
+
+</script>
+
+<style scoped>
+
+.fingerprint-wrapper {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.svg-wrapper {
+  height: 100%;
+  width: 100%;
+}
+
+svg {
+  height: 100%;
+  width: 100%;
+}
+
+.chart-overlay {
+  pointer-events: none;
+}
+
+.highlighted {
+  opacity: 1;
+}
+
+.unhighlighted {
+  opacity: 0.5;
+}
+
+.legend {
+  display: flex;
+  flex-direction: column;
+}
+
+.category-labels {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  text-transform: uppercase;
+}
+
+.metric-label {
+  text-align: center;
+  color: var(--dark-gray);
+}
+
+.metric-label.active {
+  color: var(--white);
+}
+</style>

--- a/vacs-map-app/src/components/DistributionPlot.vue
+++ b/vacs-map-app/src/components/DistributionPlot.vue
@@ -70,11 +70,11 @@ const metaExtent = computed(() => {
 const colorExtent = computed(() => {
   // want to get extent across all scenarios and included crops so that comparisons are more useful
   const extents = []
-  availableModels.value.forEach(s => {
-    const column = [selectedMetric.value, selectedCrop.value, s].join("_");
+  availableModels.value.forEach((s) => {
+    const column = [selectedMetric.value, selectedCrop.value, s].join('_')
     extents.push(cropYieldsStore.getExtent(column))
   })
-  return [d3.min(extents.map(d => d[0])), d3.min(extents.map(d => d[1]))];
+  return [d3.min(extents.map((d) => d[0])), d3.min(extents.map((d) => d[1]))]
 })
 
 const gridCells = computed(() => {
@@ -100,8 +100,9 @@ const xScale = computed(() => {
 })
 
 const getCellColor = (value) => {
-  if (!value) return 'transparent';
-  const scale = d3.scaleLinear()
+  if (!value) return 'transparent'
+  const scale = d3
+    .scaleLinear()
     .domain([colorExtent.value[0], 0, colorExtent.value[1]])
     .range([divergingScheme.min, divergingScheme.center, divergingScheme.max])
     .clamp(true)

--- a/vacs-map-app/src/components/ExploreSidebar.vue
+++ b/vacs-map-app/src/components/ExploreSidebar.vue
@@ -61,7 +61,7 @@ const getCropsByGroup = (group) => {
 .sidebar {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: 1rem;
   margin-left: var(--page-horizontal-margin);
   padding-right: 2rem;
   padding-bottom: 2rem;

--- a/vacs-map-app/src/components/ExploreSidebar.vue
+++ b/vacs-map-app/src/components/ExploreSidebar.vue
@@ -3,12 +3,7 @@
     <div class="crop-selection">
       <select v-model="selectedCrop" class="crop-picker">
         <optgroup v-for="group in availableCropGroups" :key="group" :label="group">
-
-          <option 
-            v-for="crop in getCropsByGroup(group)" 
-            :key="crop.id" 
-            :value="crop.id"
-          >
+          <option v-for="crop in getCropsByGroup(group)" :key="crop.id" :value="crop.id">
             {{ crop.label }}
           </option>
         </optgroup>
@@ -47,20 +42,19 @@ import CardWrapper from './CardWrapper.vue'
 
 const filtersStore = useFiltersStore()
 const cropInformationStore = useCropInformationStore()
-const { availableCrops, selectedCrop, availableModels, selectedModel, availableCropGroups } = storeToRefs(filtersStore)
+const { availableCrops, selectedCrop, availableModels, selectedModel, availableCropGroups } =
+  storeToRefs(filtersStore)
 const { data: cropInformation } = storeToRefs(cropInformationStore)
 
 const futureScenarios = computed(() => availableModels.value.filter((d) => d.startsWith('future')))
 
 const selectedCropInfo = computed(() => {
-  return cropInformation?.value?.find(d => d.id === selectedCrop.value);
+  return cropInformation?.value?.find((d) => d.id === selectedCrop.value)
 })
 
 const getCropsByGroup = (group) => {
-  return cropInformation?.value?.filter(crop => crop.crop_group === group);
+  return cropInformation?.value?.filter((crop) => crop.crop_group === group)
 }
-
-
 </script>
 
 <style scoped>

--- a/vacs-map-app/src/components/ExploreSidebar.vue
+++ b/vacs-map-app/src/components/ExploreSidebar.vue
@@ -17,7 +17,9 @@
       <span> {{ selectedCropInfo?.description }}</span>
     </div>
 
-    <div class="crop-fingerprint">crop fingerprint</div>
+    <div class="crop-fingerprint">
+      <CropFingerprint :crop-id="selectedCrop" />
+    </div>
 
     <div class="scenarios">
       <CardWrapper
@@ -40,6 +42,7 @@ import { storeToRefs } from 'pinia'
 import { useFiltersStore } from '@/stores/filters'
 import { useCropInformationStore } from '../stores/cropInformation'
 import DistributionPlot from './DistributionPlot.vue'
+import CropFingerprint from './CropFingerprint.vue'
 import CardWrapper from './CardWrapper.vue'
 
 const filtersStore = useFiltersStore()
@@ -80,8 +83,6 @@ const getCropsByGroup = (group) => {
 .crop-fingerprint {
   width: 100%;
   height: 40%;
-  border: 1px solid var(--white);
-  border-radius: 0.5rem;
 }
 
 .scenarios {

--- a/vacs-map-app/src/components/MapContainerColorAcrossScenarios.vue
+++ b/vacs-map-app/src/components/MapContainerColorAcrossScenarios.vue
@@ -17,71 +17,58 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
-import { storeToRefs } from 'pinia';
-import BaseMap from '@/components/BaseMap.vue';
-import { useFiltersStore } from '@/stores/filters';
-import { useCropYieldsStore } from '@/stores/cropYields';
-import GridSource from './GridSource.vue';
-import GridOverlay from './GridOverlay.vue';
-import * as d3 from 'd3';
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import BaseMap from '@/components/BaseMap.vue'
+import { useFiltersStore } from '@/stores/filters'
+import { useCropYieldsStore } from '@/stores/cropYields'
+import GridSource from './GridSource.vue'
+import GridOverlay from './GridOverlay.vue'
+import * as d3 from 'd3'
 
-const sourceId = 'cropGrid';
-const cropYieldsStore = useCropYieldsStore();
-const filtersStore = useFiltersStore();
+const sourceId = 'cropGrid'
+const cropYieldsStore = useCropYieldsStore()
+const filtersStore = useFiltersStore()
 
-const {
-  selectedCrop,
-  selectedMetric,
-  selectedModel,
-  availableModels
-} = storeToRefs(filtersStore);
-
+const { selectedCrop, selectedMetric, selectedModel, availableModels } = storeToRefs(filtersStore)
 
 const selectedColumn = computed(() => {
   if (!selectedMetric.value || !selectedCrop.value || !selectedModel.value) {
-    return null;
+    return null
   }
 
-  return [
-    selectedMetric.value,
-    selectedCrop.value,
-    selectedModel.value,
-  ].join('_');
-});
+  return [selectedMetric.value, selectedCrop.value, selectedModel.value].join('_')
+})
 
 // to get extent across scenarios
 const scenarios = computed(() => {
   if (selectedMetric.value === 'yieldratio') {
-    return availableModels.value.filter(d => d.startsWith('future'))
+    return availableModels.value.filter((d) => d.startsWith('future'))
   } else {
-    return availableModels.value;
+    return availableModels.value
   }
-});
+})
 
 // to get extent across scenarios
 const columns = computed(() => {
   if (!selectedMetric.value || !selectedCrop.value || !scenarios.value.length) {
-    return null;
+    return null
   }
-  return scenarios.value.map(s => [selectedMetric.value, selectedCrop.value, s].join('_'));
-});
+  return scenarios.value.map((s) => [selectedMetric.value, selectedCrop.value, s].join('_'))
+})
 
 const selectedExtent = computed(() => {
-  if (!columns.value?.length) return null;
+  if (!columns.value?.length) return null
 
-  const extents = columns.value.map(c => cropYieldsStore.getExtent(c));
+  const extents = columns.value.map((c) => cropYieldsStore.getExtent(c))
 
-  return [
-    d3.min(extents, extent => d3.min(extent)),
-    d3.max(extents, extent => d3.max(extent))
-  ];
-});
+  return [d3.min(extents, (extent) => d3.min(extent)), d3.max(extents, (extent) => d3.max(extent))]
+})
 
 const selectedColumnQuintiles = computed(() => {
-  if (!selectedColumn.value) return null;
-  return cropYieldsStore.getQuintiles(selectedColumn.value);
-});
+  if (!selectedColumn.value) return null
+  return cropYieldsStore.getQuintiles(selectedColumn.value)
+})
 </script>
 
 <style scoped></style>

--- a/vacs-map-app/src/components/MapHomepage.vue
+++ b/vacs-map-app/src/components/MapHomepage.vue
@@ -8,13 +8,7 @@
         </radialGradient>
       </defs>
       <g class="basemap">
-        <circle 
-          :cx="width/2"
-          :cy="height/2"
-          :r="width/2 - 70"
-          fill="url('#globeGradient')" 
-        />
-
+        <circle :cx="width / 2" :cy="height / 2" :r="width / 2 - 70" fill="url('#globeGradient')" />
       </g>
       <g class="grid-cells">
         <circle
@@ -52,49 +46,53 @@ const { data: cropYieldsData } = storeToRefs(cropYieldsStore)
 const { data: gridData } = storeToRefs(gridStore)
 const { availableCrops, availableModels } = storeToRefs(filtersStore)
 
-const wrapperRef = ref(null);
-const inset = -20;
-const width = ref(0);
-const height = ref(0);
-const timer = ref(null);
+const wrapperRef = ref(null)
+const inset = -20
+const width = ref(0)
+const height = ref(0)
+const timer = ref(null)
 
 // these variables control what crop/scenario we are currently looking at
-const selectedCropIndex = ref(0);
-const selectedScenarioIndex = ref(0);
-const switchCrop = ref(false);
+const selectedCropIndex = ref(0)
+const selectedScenarioIndex = ref(0)
+const switchCrop = ref(false)
 
 useResizeObserver(wrapperRef, ([entry]) => {
-  width.value = entry.contentRect.width;
-  height.value = entry.contentRect.height;
-});
+  width.value = entry.contentRect.width
+  height.value = entry.contentRect.height
+})
 
-const futureScenarios = computed(() => availableModels.value.filter(d => d.startsWith('future')));
+const futureScenarios = computed(() => availableModels.value.filter((d) => d.startsWith('future')))
 
-const selectedCrop = computed(() => availableCrops.value[selectedCropIndex.value]);
-const selectedScenario = computed(() => futureScenarios.value[selectedScenarioIndex.value]);
-const selectedColumn = computed(() => `yieldratio_${selectedCrop.value}_${selectedScenario.value}`);
+const selectedCrop = computed(() => availableCrops.value[selectedCropIndex.value])
+const selectedScenario = computed(() => futureScenarios.value[selectedScenarioIndex.value])
+const selectedColumn = computed(() => `yieldratio_${selectedCrop.value}_${selectedScenario.value}`)
 
 const scenarioColumns = computed(() => {
-  return availableModels.value.filter(d => d.startsWith('future')).map(
-    d => `yieldratio_${selectedCrop.value}_${d}`
-  )
+  return availableModels.value
+    .filter((d) => d.startsWith('future'))
+    .map((d) => `yieldratio_${selectedCrop.value}_${d}`)
 })
 
 const selectedExtent = computed(() => {
-  const extents = scenarioColumns.value.map(d => cropYieldsStore.getExtent(d))
-  return [
-    d3.min(extents, extent => d3.min(extent)),
-    d3.max(extents, extent => d3.max(extent))
-  ];
+  const extents = scenarioColumns.value.map((d) => cropYieldsStore.getExtent(d))
+  return [d3.min(extents, (extent) => d3.min(extent)), d3.max(extents, (extent) => d3.max(extent))]
 })
-  
-const outline = ({type: "Sphere"});
+
+const outline = { type: 'Sphere' }
 
 // this handles the projection, with translation and scale based on window size (responsive)
 const projection = computed(() => {
-  return d3.geoOrthographic()
-    .rotate([-15,-3])
-    .fitExtent([[inset, inset], [width.value - inset, height.value - inset]], outline)
+  return d3
+    .geoOrthographic()
+    .rotate([-15, -3])
+    .fitExtent(
+      [
+        [inset, inset],
+        [width.value - inset, height.value - inset]
+      ],
+      outline
+    )
 })
 
 const gridCells = computed(() => {
@@ -127,18 +125,19 @@ const updateGrid = () => {
   // if we've gotten through all scenarios - increment selected crop
   if (switchCrop.value) {
     if (selectedCropIndex.value === availableCrops.value.length - 1) {
-      selectedCropIndex.value = 0;
+      selectedCropIndex.value = 0
     } else {
-      selectedCropIndex.value++;
+      selectedCropIndex.value++
     }
-    switchCrop.value = false;
-  } else { //increment scenario
+    switchCrop.value = false
+  } else {
+    //increment scenario
     if (selectedScenarioIndex.value === futureScenarios.value.length - 1) {
-      selectedScenarioIndex.value = 0;
+      selectedScenarioIndex.value = 0
     } else {
-      selectedScenarioIndex.value++;
+      selectedScenarioIndex.value++
     }
-    switchCrop.value = true;
+    switchCrop.value = true
   }
 }
 

--- a/vacs-map-app/src/components/SandLayer.vue
+++ b/vacs-map-app/src/components/SandLayer.vue
@@ -45,7 +45,7 @@ const getRasterColor = () => {
     // const interpolator = d3.interpolatePiYG;
 
     // Or define your own:
-    const interpolator = d3.interpolateHsl("transparent", "orange");
+    const interpolator = d3.interpolateHsl('transparent', 'orange')
 
     // const interpolator = d3.interpolateInferno
     return interpolator(value)

--- a/vacs-map-app/src/components/SoilCarbonLayer.vue
+++ b/vacs-map-app/src/components/SoilCarbonLayer.vue
@@ -37,7 +37,7 @@ const maxRasterValue = 100
 const getRasterColor = () => {
   const getColor = (value) => {
     // const interpolator = d3.interpolateBrBG;
-    const interpolator = d3.interpolateHsl("hsla(143, 52%, 13%, 0)", "#6DACA4");
+    const interpolator = d3.interpolateHsl('hsla(143, 52%, 13%, 0)', '#6DACA4')
     // const interpolator = d3.interpolatePiYG;
     // const interpolator = d3.interpolateCubehelixDefault
 

--- a/vacs-map-app/src/stores/cropInformation.js
+++ b/vacs-map-app/src/stores/cropInformation.js
@@ -8,30 +8,30 @@ export const useCropInformationStore = defineStore('cropInformation', () => {
   const loading = ref(false)
 
   const load = async () => {
-    if (loading.value || data.value) return false;
-    loading.value = true;
+    if (loading.value || data.value) return false
+    loading.value = true
 
-    let general = await d3.csv(getDataUrl('crop-info-general.csv'), d3.autoType);
-    let genetic = await d3.csv(getDataUrl('crop-info-genetic.csv'), d3.autoType);
-    let nutritional = await d3.csv(getDataUrl('crop-info-nutritional.csv'), d3.autoType);
-    let biophysical = await d3.csv(getDataUrl('crop-info-biophysical.csv'), d3.autoType);
+    let general = await d3.csv(getDataUrl('crop-info-general.csv'), d3.autoType)
+    let genetic = await d3.csv(getDataUrl('crop-info-genetic.csv'), d3.autoType)
+    let nutritional = await d3.csv(getDataUrl('crop-info-nutritional.csv'), d3.autoType)
+    let biophysical = await d3.csv(getDataUrl('crop-info-biophysical.csv'), d3.autoType)
 
     const getIndicators = (array, id) => {
-      return Object.fromEntries(Object.entries(array.find(d => d.id === id)).slice(1));
+      return Object.fromEntries(Object.entries(array.find((d) => d.id === id)).slice(1))
     }
 
     general = general.map((d) => {
       const indicators = {
         genetic: getIndicators(genetic, d.id),
         nutritional: getIndicators(nutritional, d.id),
-        biophysical: getIndicators(biophysical, d.id),
+        biophysical: getIndicators(biophysical, d.id)
       }
       return {
         ...d,
         indicators: indicators
       }
     })
-    data.value = Object.freeze(general);
+    data.value = Object.freeze(general)
   }
 
   return {

--- a/vacs-map-app/src/stores/filters.js
+++ b/vacs-map-app/src/stores/filters.js
@@ -62,17 +62,11 @@ export const useFiltersStore = defineStore('filters', () => {
   const { data: cropInfo } = storeToRefs(cropInformationStore)
 
   watch(cropInfo, () => {
+    availableCropGroups.value = Array.from(new Set(cropInfo.value?.map((d) => d.crop_group)))
 
-    availableCropGroups.value = Array.from(
-      new Set(cropInfo.value?.map(d => d.crop_group))
-    );
+    cropSortByOptions.value = Array.from(Object.keys(cropInfo.value?.[0].indicators?.nutritional))
 
-    cropSortByOptions.value = Array.from(Object.keys(
-      cropInfo.value?.[0].indicators?.nutritional
-    ));
-
-    cropSortBy.value = cropSortByOptions.value[0];
-
+    cropSortBy.value = cropSortByOptions.value[0]
   })
 
   return {

--- a/vacs-map-app/src/utils/colors.js
+++ b/vacs-map-app/src/utils/colors.js
@@ -3,3 +3,9 @@ export const divergingScheme = {
   center: '#424242',
   max: '#13F364'
 }
+
+export const fingerprintScheme = {
+  nutritional: '#CD4A51',
+  genetic: '#33C4D4',
+  biophysical: '#BB86FC',
+}

--- a/vacs-map-app/src/utils/colors.js
+++ b/vacs-map-app/src/utils/colors.js
@@ -7,5 +7,5 @@ export const divergingScheme = {
 export const fingerprintScheme = {
   nutritional: '#CD4A51',
   genetic: '#33C4D4',
-  biophysical: '#BB86FC',
+  biophysical: '#BB86FC'
 }

--- a/vacs-map-app/src/utils/colors.js
+++ b/vacs-map-app/src/utils/colors.js
@@ -5,7 +5,7 @@ export const divergingScheme = {
 }
 
 export const fingerprintScheme = {
-  nutritional: '#CD4A51',
-  genetic: '#33C4D4',
-  biophysical: '#BB86FC'
+  nutritional: '#7E899C',
+  genetic: '#DDB424',
+  biophysical: '#8482BC'
 }


### PR DESCRIPTION
Closes #12 

This is a first pass at the crop fingerprints going off some of the comments in [figma](https://www.figma.com/file/o3LQntPkm5yC5SqSX6nGn3/Design?type=design&node-id=389%3A5074&mode=design&t=RN4hTbYgM4WIkvjh-1)

Having a little trouble figuring out where to put all the labels on what ends up being a pretty small chart, and some of the lables are pretty long. I also don't love having sideways / upside down labels. So wondering if something along these lines (but more polished) would work, with category labels color coded, and metric labels appearing on hover.

I also think this implementation of the benchmark figures needs some work, and it might make sense to go back to the lines that agmip uses in their charts.

### without any hover:
<img width="405" alt="Screenshot 2023-11-25 at 3 39 28 PM" src="https://github.com/earthrise-media/vacs-map/assets/25800091/8f659a43-2e18-4961-a2c0-700b2c8fbd78">

### when you're looking at a benchmark crop and hovering:
<img width="425" alt="Screenshot 2023-11-25 at 3 27 38 PM" src="https://github.com/earthrise-media/vacs-map/assets/25800091/f6d65f7f-9143-459e-a838-1e064d259c67">

### when you're looking at a non-benchmark crop and hovering:
<img width="400" alt="Screenshot 2023-11-25 at 3 28 02 PM" src="https://github.com/earthrise-media/vacs-map/assets/25800091/295a44e8-9aae-446e-944c-b3759c574711">
