### PR TITLE
Update explore page layout

### DIFF
--- a/vacs-map-app/src/MapExplorer.vue
+++ b/vacs-map-app/src/MapExplorer.vue
@@ -9,7 +9,7 @@
           </template>
         </component>
         <div class="overlay-wrapper">
-          <OverviewTop class="interactive" />
+          <OverviewTop class="interactive"/>
           <div class="map-overlay desktop">
             <div class="overlay-left">
               <ExploreSidebar class="interactive" ref="overlayLeftRef" />
@@ -123,6 +123,7 @@ onUnmounted(() => {
 }
 
 .map-overlay {
+  height: 1rem;
   flex-grow: 1;
   display: flex;
   justify-content: space-between;
@@ -131,8 +132,12 @@ onUnmounted(() => {
 }
 
 .overlay-left {
+  height: 100%;
+  margin-left: var(--page-horizontal-margin);
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: space-between;
   align-items: flex-end;
   gap: 2rem;
 }

--- a/vacs-map-app/src/components/CropFingerprint.vue
+++ b/vacs-map-app/src/components/CropFingerprint.vue
@@ -220,6 +220,7 @@ const arc = computed(() => {
 }
 .svg-wrapper {
   height: 100%;
+  margin-top: 1rem;
 }
 
 svg {

--- a/vacs-map-app/src/components/ExploreSidebar.vue
+++ b/vacs-map-app/src/components/ExploreSidebar.vue
@@ -115,7 +115,7 @@ const openScenarioModal = (s) => {
   gap: 1rem;
   justify-content: space-between;
   height: 100%;
-  margin-left: var(--page-horizontal-margin);
+  max-height: 50rem;
   padding: 1.25rem;
   width: 450px;
   border: 1px solid var(--dark-gray);

--- a/vacs-map-app/src/components/MapLegend.vue
+++ b/vacs-map-app/src/components/MapLegend.vue
@@ -65,6 +65,7 @@ const openYieldRatioModal = () => {
   flex-direction: column;
   gap: 0.25rem;
   width: 18rem;
+  margin-top: auto;
 }
 
 .legend-title {


### PR DESCRIPTION
Closes #93 

This addresses a couple issues the explore layout was having:

On smaller screens the sidebar overflow wasn't triggering, leading to the legend and sidebar getting cut off

![Screenshot 2023-12-05 at 10 45 34 AM](https://github.com/earthrise-media/vacs-map/assets/25800091/3d4c0589-7609-4bc4-b764-1e568906c712)

And in especially tall windows the fingerprint layout left a lot of blank space
![Screenshot 2023-12-05 at 10 45 43 AM](https://github.com/earthrise-media/vacs-map/assets/25800091/dc4deb0d-e076-44e8-b528-cdebeb84dd80)


This fixes the overflow issue, and gives the sidebar a maximum height, pinning it to the top left, and moving the legend underneath it if there is room: 

![Screenshot 2023-12-05 at 10 42 19 AM](https://github.com/earthrise-media/vacs-map/assets/25800091/6ae3cfd4-638e-4606-8c0f-8175d02401a3)

